### PR TITLE
adding exception error to the result

### DIFF
--- a/AsaApi/Core/Private/Tools/Requests.cpp
+++ b/AsaApi/Core/Private/Tools/Requests.cpp
@@ -155,7 +155,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200
@@ -193,7 +193,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200
@@ -231,7 +231,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200
@@ -285,7 +285,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200


### PR DESCRIPTION
- for more plugin dev control regarding error and results instead of suppressing it allowing plugin dev to parse the result either log it back as error or suppress it because not all exceptions are urgent error like timeouts