### PR TITLE
fix(commands): prevent heap corruption and iterator invalidation during removal

### DIFF
--- a/AsaApi/Core/Private/Commands.cpp
+++ b/AsaApi/Core/Private/Commands.cpp
@@ -68,18 +68,21 @@ namespace AsaApi
 
 	bool Commands::CheckChatCommands(AShooterPlayerController* shooter_player_controller, FString* message, int mode, int platform)
 	{
-		return CheckCommands<ChatCommand>(*message, chat_commands_, shooter_player_controller, message, mode, platform);
+		const auto tmp_chat_commands = chat_commands_;
+		return CheckCommands<ChatCommand>(*message, tmp_chat_commands, shooter_player_controller, message, mode, platform);
 	}
 
 	bool Commands::CheckConsoleCommands(APlayerController* a_player_controller, FString* cmd, bool write_to_log)
 	{
-		return CheckCommands<ConsoleCommand>(*cmd, console_commands_, a_player_controller, cmd, write_to_log);
+		const auto tmp_console_commands = console_commands_;
+		return CheckCommands<ConsoleCommand>(*cmd, tmp_console_commands, a_player_controller, cmd, write_to_log);
 	}
 
 	bool Commands::CheckRconCommands(RCONClientConnection* rcon_client_connection, RCONPacket* rcon_packet,
 		UWorld* u_world)
 	{
-		return CheckCommands<RconCommand>(rcon_packet->Body, rcon_commands_, rcon_client_connection, rcon_packet,
+		const auto tmp_rcon_commands = rcon_commands_;
+		return CheckCommands<RconCommand>(rcon_packet->Body, tmp_rcon_commands, rcon_client_connection, rcon_packet,
 			u_world);
 	}
 

--- a/AsaApi/Core/Private/Commands.h
+++ b/AsaApi/Core/Private/Commands.h
@@ -77,8 +77,7 @@ namespace AsaApi
 
 			if (iter != commands.end())
 			{
-				commands.erase(std::remove(commands.begin(), commands.end(), *iter), commands.end());
-
+				commands.erase(iter);
 				return true;
 			}
 


### PR DESCRIPTION
## Summary

Fixes sporadic crashes during plugin hot reload caused by two issues in the command removal system:

1. **Heap corruption from `erase-remove` idiom with `shared_ptr`** — The redundant `std::remove` after `find_if` caused unpredictable refcount changes during move-assignment, leading to type confusion crashes
2. **Iterator invalidation** — Callbacks could modify command vectors while `CheckCommands` was iterating them

## Changes

### `Commands.h` — Replace erase-remove with direct erase

```cpp
// Before (problematic)
commands.erase(std::remove(commands.begin(), commands.end(), *iter), commands.end());

// After (safe)
commands.erase(iter);
```

`find_if` already returns the exact iterator — using `std::remove` afterward is redundant and dangerous with `shared_ptr`.

### `Commands.cpp` — Copy vectors before iteration

```cpp
// Before (unsafe)
return CheckCommands<ChatCommand>(*message, chat_commands_, ...);

// After (safe)
const auto tmp_chat_commands = chat_commands_;
return CheckCommands<ChatCommand>(*message, tmp_chat_commands, ...);
```

This matches the existing pattern already used in `CheckOnTickCallbacks`, `CheckOnTimerCallbacks`, and `CheckOnChatMessageCallbacks`.

## Test plan

- [x] Verified pattern consistency with existing `CheckOn<T>Callbacks()` methods
- [x] Hot reload plugin multiple times without crash
- [x] Verify commands still register/unregister correctly