### PR TITLE
Fix DetourTransactionCommit failed (err=5)

### DIFF
--- a/AsaApi/Core/Private/Hooks.cpp
+++ b/AsaApi/Core/Private/Hooks.cpp
@@ -37,7 +37,7 @@ namespace
 					FALSE, te.th32ThreadID);
 				if (hThread)
 					DetourUpdateThread(hThread);
-				
+
 			} while (Thread32Next(hSnap, &te));
 		}
 		CloseHandle(hSnap);
@@ -129,9 +129,9 @@ namespace API
 
 		std::unique_lock installLock(g_hookInstallMutex);
 		g_rebuildDone.wait(installLock, [&]
-		{
-			return !rebuilding_.count(func_name);
-		});
+			{
+				return !rebuilding_.count(func_name);
+			});
 
 		return SetHookInternalImplNoWait(func_name, detour, original, hOwner);
 	}
@@ -147,11 +147,11 @@ namespace API
 			: hook_vector.back()->original;
 
 		bool ok = RunTransaction([&]()
-		{
-			const LONG attachErr = DetourAttach(original, detour);
-			if (attachErr != NO_ERROR)
-				Log::GetLog()->error("[{}] DetourAttach failed for {} (err={})", ModuleName(hOwner), func_name, attachErr);
-		});
+			{
+				const LONG attachErr = DetourAttach(&new_target, detour);
+				if (attachErr != NO_ERROR)
+					Log::GetLog()->error("[{}] DetourAttach failed for {} (err={})", ModuleName(hOwner), func_name, attachErr);
+			});
 
 		if (!ok)
 		{
@@ -159,6 +159,8 @@ namespace API
 			*original = nullptr;
 			return false;
 		}
+
+		*original = new_target;
 
 		if (extended_debug_)
 			Log::GetLog()->info("[{}] Hook installed for {} (trampoline=0x{:X})", ModuleName(hOwner), func_name, reinterpret_cast<ULONG_PTR>(*original));
@@ -177,26 +179,26 @@ namespace API
 		}
 
 		const auto makeChainSnapshot = [](const std::vector<std::shared_ptr<Hook>>& vec) -> std::string
-		{
-			if (vec.empty())
-				return "0 hooks: <empty>";
-
-			std::string s = std::to_string(vec.size()) + " hooks: ";
-			for (std::size_t i = 0; i < vec.size(); ++i)
 			{
-				char buf[24];
-				std::snprintf(buf, sizeof(buf), "0x%llX",
-					static_cast<unsigned long long>(reinterpret_cast<ULONG_PTR>(vec[i]->detour)));
-				s += '[';
-				s += ModuleName(vec[i]->hOwnerModule);
-				s += '(';
-				s += buf;
-				s += ")]";
-				if (i + 1 < vec.size())
-					s += " -> ";
-			}
-			return s;
-		};
+				if (vec.empty())
+					return "0 hooks: <empty>";
+
+				std::string s = std::to_string(vec.size()) + " hooks: ";
+				for (std::size_t i = 0; i < vec.size(); ++i)
+				{
+					char buf[24];
+					std::snprintf(buf, sizeof(buf), "0x%llX",
+						static_cast<unsigned long long>(reinterpret_cast<ULONG_PTR>(vec[i]->detour)));
+					s += '[';
+					s += ModuleName(vec[i]->hOwnerModule);
+					s += '(';
+					s += buf;
+					s += ")]";
+					if (i + 1 < vec.size())
+						s += " -> ";
+				}
+				return s;
+			};
 
 		std::shared_ptr<Hook> removedHook;
 		std::vector<std::shared_ptr<Hook>> survivors;
@@ -228,14 +230,14 @@ namespace API
 			rebuilding_.insert(func_name);
 
 			bool ok = RunTransaction([&]()
-			{
-				for (const auto& h : hook_vector)
 				{
-					const LONG detachErr = DetourDetach(h->original, h->detour);
-					if (detachErr != NO_ERROR)
-						Log::GetLog()->error("[{}] DetourDetach failed for {} (err={})", ModuleName(removedHook->hOwnerModule), func_name, detachErr);
-				}
-			});
+					for (const auto& h : hook_vector)
+					{
+						const LONG detachErr = DetourDetach(h->original, h->detour);
+						if (detachErr != NO_ERROR)
+							Log::GetLog()->error("[{}] DetourDetach failed for {} (err={})", ModuleName(removedHook->hOwnerModule), func_name, detachErr);
+					}
+				});
 
 			if (!ok)
 			{

--- a/AsaApi/Core/Private/Hooks.cpp
+++ b/AsaApi/Core/Private/Hooks.cpp
@@ -144,7 +144,7 @@ namespace API
 		LPVOID target = Offsets::Get().GetAddress(func_name);
 		LPVOID new_target = hook_vector.empty()
 			? target
-			: hook_vector.back()->detour;
+			: hook_vector.back()->original;
 
 		bool ok = RunTransaction([&]()
 		{

--- a/AsaApi/Core/Private/Hooks.cpp
+++ b/AsaApi/Core/Private/Hooks.cpp
@@ -35,8 +35,19 @@ namespace
 
 				HANDLE hThread = OpenThread(THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT | THREAD_SET_CONTEXT,
 					FALSE, te.th32ThreadID);
-				if (hThread)
-					DetourUpdateThread(hThread);
+				if (!hThread)
+					continue;
+
+				// Pre-test suspendability and skip threads we can't suspend.
+				const DWORD suspendCount = SuspendThread(hThread);
+				if (suspendCount == (DWORD)-1)
+				{
+					CloseHandle(hThread);
+					continue;
+				}
+				ResumeThread(hThread);
+
+				DetourUpdateThread(hThread);
 
 			} while (Thread32Next(hSnap, &te));
 		}
@@ -73,7 +84,13 @@ namespace
 
 		UpdateAllThreads();
 
-		fn();
+		const bool attachOk = fn();
+
+		if (!attachOk)
+		{
+			DetourTransactionAbort();
+			return false;
+		}
 
 		const LONG err = DetourTransactionCommit();
 		if (err != NO_ERROR)
@@ -144,13 +161,17 @@ namespace API
 		LPVOID target = Offsets::Get().GetAddress(func_name);
 		LPVOID new_target = hook_vector.empty()
 			? target
-			: hook_vector.back()->original;
+			: *hook_vector.back()->original;
 
-		bool ok = RunTransaction([&]()
+		bool ok = RunTransaction([&]() -> bool
 			{
 				const LONG attachErr = DetourAttach(&new_target, detour);
 				if (attachErr != NO_ERROR)
+				{
 					Log::GetLog()->error("[{}] DetourAttach failed for {} (err={})", ModuleName(hOwner), func_name, attachErr);
+					return false;
+				}
+				return true;
 			});
 
 		if (!ok)
@@ -229,14 +250,19 @@ namespace API
 
 			rebuilding_.insert(func_name);
 
-			bool ok = RunTransaction([&]()
+			bool ok = RunTransaction([&]() -> bool
 				{
+					bool allOk = true;
 					for (const auto& h : hook_vector)
 					{
 						const LONG detachErr = DetourDetach(h->original, h->detour);
 						if (detachErr != NO_ERROR)
+						{
 							Log::GetLog()->error("[{}] DetourDetach failed for {} (err={})", ModuleName(removedHook->hOwnerModule), func_name, detachErr);
+							allOk = false;
+						}
 					}
+					return allOk;
 				});
 
 			if (!ok)

--- a/AsaApi/Core/Private/Hooks.cpp
+++ b/AsaApi/Core/Private/Hooks.cpp
@@ -79,7 +79,6 @@ namespace
 		if (err != NO_ERROR)
 		{
 			Log::GetLog()->error("DetourTransactionCommit failed (err={})", err);
-			DetourTransactionAbort();
 			return false;
 		}
 		return true;
@@ -141,7 +140,11 @@ namespace API
 		LPVOID* original, HMODULE hOwner)
 	{
 		auto& hook_vector = all_hooks_[func_name];
-		*original = Offsets::Get().GetAddress(func_name);
+
+		LPVOID target = Offsets::Get().GetAddress(func_name);
+		LPVOID new_target = hook_vector.empty()
+			? target
+			: hook_vector.back()->detour;
 
 		bool ok = RunTransaction([&]()
 		{


### PR DESCRIPTION
Reverts to 1.19 implementation where if detour is already installed it was taken from the hook_vector

Also removes pointless DetourTransactionAbort(); in RunTransaction, as it's already over after the error