### PR TITLE
Prevent detach-time crash by skipping API teardown in DllMain

### DIFF
--- a/AsaApi/main.cpp
+++ b/AsaApi/main.cpp
@@ -128,3 +128,14 @@ extern "C" ARK_API void InitApi()
 {
 	Init();
 }
+
+BOOL APIENTRY DllMain(HMODULE, DWORD ul_reason_for_call, LPVOID)
+{
+	if (ul_reason_for_call == DLL_PROCESS_DETACH)
+	{
+		API::game_api.release();
+	}
+
+	return 1;
+}
+


### PR DESCRIPTION
## What this changes
- Adds a `DLL_PROCESS_DETACH` handler in `AsaApi/main.cpp`.
- On detach, calls `API::game_api.release()` to avoid running API destructors during CRT/loader teardown.

## Why
There is a unhandled exception duting api dll detach resulting in the server to freeze.
The exception is a **Null Pointer Dereference (Access Violation)** occurring at address `00007ff90a6063c6`. The CPU failed while executing `mov rbx, qword ptr [r14+8]` because register **r14** pointed to an unmapped or already freed memory location (`03e6a4d0`) during the cleanup of a hash map.

```text
ExceptionAddress: 00007ff90a6063c6 (AsaApi!std::_Hash<...>::_Find_last+0x0000000000000026)
ExceptionCode: c0000005 (Access violation)
ExceptionFlags: 00000000
FirstChance: Yes
Reading address: 0000000003e6a4d8

00 AsaApi!std::_Hash<...>::_Find_last+0x26
01 AsaApi!std::_Hash<...>::contains<void>+0x66
02 AsaApi!API::Offsets::GetAddress+0x1e
03 AsaApi!FMemory::Free+0x44
04 AsaApi!std::pair<...>::~pair+0x55
05 AsaApi!std::list<...>::~list+0x3c
06 AsaApi!AsaApi::ApiUtils::scalar deleting destructor+0x18
07 AsaApi!API::ArkBaseApi::scalar deleting destructor+0x22
08 ucrtbase!<lambda_...>::operator()+0xa5
09 ucrtbase!__crt_seh_guarded_call+0x3b
0a ucrtbase!execute_onexit_table+0x3d
0b AsaApi!dllmain_crt_process_detach+0x45
0c AsaApi!dllmain_dispatch+0xe6
0d ntdll!LdrpCallInitRoutineInternal+0x22
0e ntdll!LdrpCallInitRoutine+0x93
0f ntdll!LdrShutdownProcess+0x17f
10 ntdll!RtlExitUserProcess+0x9e
11 KERNEL32!ExitProcessImplementation+0xb
12 ucrtbase!common_exit+0xc7
13 ArkAscendedServer!__scrt_common_main_seh+0x168
```
## Result
- Runtime behavior is unchanged while the server is running.
- Detach/shutdown is more stable by avoiding unsafe destructor-time work.

## Notes
This is a pragmatic stability fix.  
Long-term, the cleaner approach is explicit lifecycle shutdown (host-driven `ShutdownApi()` + idempotent, guarded destructors), so teardown happens before detach.

/fixes #52 