### PR TITLE
per-plugin SupportsHotReload control

### DIFF
--- a/AsaApi/Core/Private/PluginManager/PluginManager.cpp
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.cpp
@@ -164,7 +164,8 @@ namespace API
 		return loaded_plugins_.emplace_back(std::make_shared<Plugin>(h_module, plugin_name, plugin_info["FullName"],
 			plugin_info["Description"], plugin_info["Version"],
 			plugin_info["MinApiVersion"],
-			plugin_info["Dependencies"]));
+			plugin_info["Dependencies"],
+			plugin_info.value("SupportsHotReload", true)));
 	}
 
 	void PluginManager::UnloadPlugin(const std::string& plugin_name) noexcept(false)
@@ -216,6 +217,7 @@ namespace API
 		}
 
 		loaded_plugins_.erase(remove(loaded_plugins_.begin(), loaded_plugins_.end(), *iter), loaded_plugins_.end());
+		hot_reload_warned_plugins_.erase(plugin_name);
 	}
 
 	nlohmann::json PluginManager::ReadPluginInfo(const std::string& plugin_name)
@@ -240,6 +242,7 @@ namespace API
 			plugin_info_result["Version"] = plugin_info.value("Version", 1.00f);
 			plugin_info_result["MinApiVersion"] = plugin_info.value("MinApiVersion", .0f);
 			plugin_info_result["Dependencies"] = plugin_info.value("Dependencies", std::vector<std::string>{});
+			plugin_info_result["SupportsHotReload"] = plugin_info.value("SupportsHotReload", true);
 		}
 		catch (const std::exception& error)
 		{
@@ -323,8 +326,22 @@ namespace API
 			const std::string plugin_file_path = plugin_folder + filename + ".dll";
 			const std::string new_plugin_file_path = plugin_folder + filename + ".dll.ArkApi";
 
-			if (fs::exists(new_plugin_file_path) && FindPlugin(filename) != loaded_plugins_.end())
+			const auto plugin_iter = FindPlugin(filename);
+			if (fs::exists(new_plugin_file_path) && plugin_iter != loaded_plugins_.end())
 			{
+				// Reads the loaded plugin's flag, not the pending .dll.ArkApi update
+				if (!(*plugin_iter)->supports_hot_reload)
+				{
+					if (hot_reload_warned_plugins_.insert(filename).second)
+					{
+						Log::GetLog()->warn(
+							"Plugin '{}' has SupportsHotReload=false. "
+							"Update pending - restart the server to apply {}.dll.ArkApi.",
+							filename, filename);
+					}
+					continue;
+				}
+
 #ifndef ATLAS_GAME // not on ATLAS
 				// Save the world in case the unload/load procedure causes crash
 				if (save_world)

--- a/AsaApi/Core/Private/PluginManager/PluginManager.cpp
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.cpp
@@ -165,7 +165,7 @@ namespace API
 			plugin_info["Description"], plugin_info["Version"],
 			plugin_info["MinApiVersion"],
 			plugin_info["Dependencies"],
-			plugin_info.value("SupportsHotReload", true)));
+			plugin_info.value("PreventUnloading", false)));
 	}
 
 	void PluginManager::UnloadPlugin(const std::string& plugin_name) noexcept(false)
@@ -176,6 +176,11 @@ namespace API
 		if (iter == loaded_plugins_.end())
 		{
 			throw std::runtime_error("Plugin " + plugin_name + " is not loaded");
+		}
+
+		if ((*iter)->prevent_unloading)
+		{
+			throw std::runtime_error("unloading is disabled (PreventUnloading=true)");
 		}
 
 		const std::string dir_path = Tools::GetCurrentDir() + "/" + game_api->GetApiName() + "/Plugins/" + plugin_name;
@@ -217,7 +222,7 @@ namespace API
 		}
 
 		loaded_plugins_.erase(remove(loaded_plugins_.begin(), loaded_plugins_.end(), *iter), loaded_plugins_.end());
-		hot_reload_warned_plugins_.erase(plugin_name);
+		prevent_unload_warned_plugins_.erase(plugin_name);
 	}
 
 	nlohmann::json PluginManager::ReadPluginInfo(const std::string& plugin_name)
@@ -242,7 +247,7 @@ namespace API
 			plugin_info_result["Version"] = plugin_info.value("Version", 1.00f);
 			plugin_info_result["MinApiVersion"] = plugin_info.value("MinApiVersion", .0f);
 			plugin_info_result["Dependencies"] = plugin_info.value("Dependencies", std::vector<std::string>{});
-			plugin_info_result["SupportsHotReload"] = plugin_info.value("SupportsHotReload", true);
+			plugin_info_result["PreventUnloading"] = plugin_info.value("PreventUnloading", false);
 		}
 		catch (const std::exception& error)
 		{
@@ -330,12 +335,12 @@ namespace API
 			if (fs::exists(new_plugin_file_path) && plugin_iter != loaded_plugins_.end())
 			{
 				// Reads the loaded plugin's flag, not the pending .dll.ArkApi update
-				if (!(*plugin_iter)->supports_hot_reload)
+				if ((*plugin_iter)->prevent_unloading)
 				{
-					if (hot_reload_warned_plugins_.insert(filename).second)
+					if (prevent_unload_warned_plugins_.insert(filename).second)
 					{
 						Log::GetLog()->warn(
-							"Plugin '{}' has SupportsHotReload=false. "
+							"Plugin '{}' has PreventUnloading=true. "
 							"Update pending - restart the server to apply {}.dll.ArkApi.",
 							filename, filename);
 					}

--- a/AsaApi/Core/Private/PluginManager/PluginManager.h
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.h
@@ -3,6 +3,7 @@
 #define WIN32_LEAN_AND_MEAN
 
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -16,14 +17,16 @@ namespace API
 	struct Plugin
 	{
 		Plugin(HINSTANCE h_module, std::string name, std::string full_name,
-		       std::string description, float version, float min_api_version, std::vector<std::string> dependencies)
+		       std::string description, float version, float min_api_version,
+		       std::vector<std::string> dependencies, bool supports_hot_reload)
 			: h_module(h_module),
 			  name(std::move(name)),
 			  full_name(std::move(full_name)),
 			  description(std::move(description)),
 			  version(version),
 			  min_api_version(min_api_version),
-			  dependencies(std::move(dependencies))
+			  dependencies(std::move(dependencies)),
+			  supports_hot_reload(supports_hot_reload)
 		{
 		}
 
@@ -34,6 +37,7 @@ namespace API
 		float version;
 		float min_api_version;
 		std::vector<std::string> dependencies;
+		bool supports_hot_reload;
 	};
 
 	class PluginManager
@@ -100,6 +104,7 @@ namespace API
 		int reload_sleep_seconds_{5};
 		bool save_world_before_reload_{true};
 		time_t next_reload_check_{5};
+		std::set<std::string> hot_reload_warned_plugins_;
 
 		std::unordered_map<std::string, DLL_DIRECTORY_COOKIE> dll_dir_cookies_{};
 		bool dll_search_initialized_{ false };

--- a/AsaApi/Core/Private/PluginManager/PluginManager.h
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.h
@@ -18,7 +18,7 @@ namespace API
 	{
 		Plugin(HINSTANCE h_module, std::string name, std::string full_name,
 		       std::string description, float version, float min_api_version,
-		       std::vector<std::string> dependencies, bool supports_hot_reload)
+		       std::vector<std::string> dependencies, bool prevent_unloading)
 			: h_module(h_module),
 			  name(std::move(name)),
 			  full_name(std::move(full_name)),
@@ -26,7 +26,7 @@ namespace API
 			  version(version),
 			  min_api_version(min_api_version),
 			  dependencies(std::move(dependencies)),
-			  supports_hot_reload(supports_hot_reload)
+			  prevent_unloading(prevent_unloading)
 		{
 		}
 
@@ -37,7 +37,7 @@ namespace API
 		float version;
 		float min_api_version;
 		std::vector<std::string> dependencies;
-		bool supports_hot_reload;
+		bool prevent_unloading;
 	};
 
 	class PluginManager
@@ -104,7 +104,7 @@ namespace API
 		int reload_sleep_seconds_{5};
 		bool save_world_before_reload_{true};
 		time_t next_reload_check_{5};
-		std::set<std::string> hot_reload_warned_plugins_;
+		std::set<std::string> prevent_unload_warned_plugins_;
 
 		std::unordered_map<std::string, DLL_DIRECTORY_COOKIE> dll_dir_cookies_{};
 		bool dll_search_initialized_{ false };


### PR DESCRIPTION
This lets plugin devs opt out of automatic hot-reloading when their plugin doesn’t support an unload and reload cycle. Server owners can also control this per plugin by editing the plugin’s PluginInfo.json.

That way `AutomaticPluginReloading `can stay set to true in the API config, while still allowing specific plugins to be disabled from hot-reloading.

New field in PluginInfo.json: `SupportsHotReload`. Set to false and the plugin gets skipped during the auto-reload check. The .dll.ArkApi  gets picked up on the next server restart as before.

Defaults to true so nothing changes for existing plugins.