### PR TITLE
fix(requests): prevent crashes on plugin unload with in-flight callbacks

### DIFF
--- a/AsaApi/Core/Private/PluginManager/PluginManager.cpp
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.cpp
@@ -11,6 +11,7 @@
 #include "../Hooks.h"
 #include <Timer.h>
 #include "../Ark/ApiUtils.h"
+#include "Requests.h"
 
 namespace API
 {
@@ -199,6 +200,9 @@ namespace API
 		{
 			pfn_unload();
 		}
+
+		// Cleans up all pending callbacks to prevent a server crash due to stale invocations after the plugin is unloaded.
+		API::Requests::Get().UnregisterCallbacksForModule((*iter)->h_module);
 
 		API::Timer::Get().UnloadTimersFromModule(FString(full_dll_path).Replace(L"/", L"\\"));
 		dynamic_cast<AsaApi::ApiUtils&>(*API::game_api->GetApiUtils()).RemoveMessagingManagerInternal(FString(full_dll_path).Replace(L"/", L"\\"));

--- a/AsaApi/Core/Private/Tools/Requests.cpp
+++ b/AsaApi/Core/Private/Tools/Requests.cpp
@@ -233,57 +233,10 @@ namespace API
 		return true;
 	}
 
-	[[deprecated]]
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::string& post_data, std::vector<std::string> headers)
-	{
-		return CreatePostRequest(url, callback, post_data, headers, 0L, 0L, 0L);
-	}
-
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
 		const std::string& post_data, std::vector<std::string> headers)
 	{
 		return CreatePostRequest(url, callback, post_data, headers, 0L, 0L, 0L);
-	}
-
-	[[deprecated]]
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::string& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		std::thread([this, url, callback, post_data, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, connectionTimeout, receiveTimeout, sendTimeout);
-
-					request.setContentType("application/x-www-form-urlencoded");
-					request.setContentLength(post_data.length());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << post_data;
-
-					Result = pimpl->GetResponse(session, response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
 	}
 
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
@@ -325,12 +278,6 @@ namespace API
 		).detach();
 
 		return true;
-	}
-
-	[[deprecated]]
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string)>& callback, const std::string& post_data, const std::string& content_type, std::vector<std::string> headers)
-	{
-		return CreatePostRequest(url, callback, post_data, content_type, headers, 0L, 0L, 0L);
 	}
 
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback, const std::string& post_data, const std::string& content_type, std::vector<std::string> headers)
@@ -338,47 +285,6 @@ namespace API
 		return CreatePostRequest(url, callback, post_data, content_type, headers, 0L, 0L, 0L);
 	}
 
-	[[deprecated]]
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::string& post_data, const std::string& content_type, std::vector<std::string> headers,
-		long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		std::thread([this, url, callback, post_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, connectionTimeout, receiveTimeout, sendTimeout);
-
-					request.setContentType(content_type);
-					request.setContentLength(post_data.length());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << post_data;
-
-					Result = pimpl->GetResponse(session, response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
-	}
-
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
 		const std::string& post_data, const std::string& content_type, std::vector<std::string> headers,
 		long connectionTimeout, long receiveTimeout, long sendTimeout)
@@ -413,62 +319,6 @@ namespace API
 					&& (int)response.getStatus() < 300;
 
 				pimpl->WriteRequest(callback, success, Result, responseHeaders);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
-	}
-
-	[[deprecated]]
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::vector<std::string>& post_ids,
-		const std::vector<std::string>& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		if (post_ids.size() != post_data.size())
-			return false;
-
-		std::thread([this, url, callback, post_ids, post_data, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, connectionTimeout, receiveTimeout, sendTimeout);
-
-					std::string body;
-
-					for (size_t i = 0; i < post_ids.size(); ++i)
-					{
-						const std::string& id = post_ids[i];
-						const std::string& data = post_data[i];
-
-						body += fmt::format("{}={}&", Poco::UTF8::escape(id), Poco::UTF8::escape(data));
-					}
-
-					body.pop_back(); // Remove last '&'
-
-					request.setContentType("application/x-www-form-urlencoded");
-					request.setContentLength(body.size());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << body;
-
-					Result = pimpl->GetResponse(session, response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result);
 				delete session;
 				session = nullptr;
 			}
@@ -532,14 +382,6 @@ namespace API
 		).detach();
 
 		return true;
-	}
-
-	[[deprecated]]
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::vector<std::string>& post_ids,
-		const std::vector<std::string>& post_data, std::vector<std::string> headers)
-	{
-		return CreatePostRequest(url, callback, post_ids, post_data, headers, 0L, 0L, 0L);
 	}
 
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,

--- a/AsaApi/Core/Private/Tools/Requests.cpp
+++ b/AsaApi/Core/Private/Tools/Requests.cpp
@@ -53,6 +53,15 @@ namespace API
     		return std::nullopt;
 		}
 
+		std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)> DeprecatedCallbackAdapter(std::function<void(bool, std::string)> callback2Args)
+		{
+			auto callback3Args = [cb = std::move(callback2Args)](bool success, std::string result, std::unordered_map<std::string, std::string> /* Unused response headers */){
+				cb(success, std::move(result));				
+			};
+
+			return callback3Args;
+		}		
+
 		using CallbackVariant = std::variant<std::function<void(bool, std::string)>, std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>>;
 	}  // namespace
 	
@@ -232,8 +241,8 @@ namespace API
     void Requests::impl::UnregisterCallbacksForModule(HMODULE pluginModule)
 	{
 		std::lock_guard<std::mutex> Guard(CallbackMutex_);
-        size_t removed = std::erase_if(CallbacksMap_, [pluginModule](const auto& owner) {
-			return owner.second.pluginModule == pluginModule;
+        size_t removed = std::erase_if(CallbacksMap_, [pluginModule](const auto& entry) {
+			return entry.second.pluginModule == pluginModule;
         });
 
 		if (removed > 0) {
@@ -431,7 +440,6 @@ namespace API
 		return true;
 	}
 
-	// NOTE: forwards to LaunchPost (default content_type "application/x-www-form-urlencoded", no timeouts)
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
 		const std::string& post_data, std::vector<std::string> headers)
 	{
@@ -444,7 +452,6 @@ namespace API
 		return pimpl->LaunchPost(url, callback, post_data, "application/x-www-form-urlencoded", headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);
 	}
 
-	// NOTE: forwards to LaunchPost (explicit content_type, no timeouts)
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback, const std::string& post_data, const std::string& content_type, std::vector<std::string> headers)
 	{
         auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
@@ -456,7 +463,6 @@ namespace API
 		return pimpl->LaunchPost(url, callback, post_data, content_type, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);
 	}
 
-	// NOTE: forwards to LaunchPost (default content_type "application/x-www-form-urlencoded", with timeouts)
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
 		const std::string& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
 	{
@@ -469,7 +475,6 @@ namespace API
 		return pimpl->LaunchPost(url, callback, post_data, "application/x-www-form-urlencoded", headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
 	}
 
-	// NOTE: forwards to LaunchPost (explicit content_type, with timeouts)
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
 		const std::string& post_data, const std::string& content_type, std::vector<std::string> headers,
 		long connectionTimeout, long receiveTimeout, long sendTimeout)
@@ -483,7 +488,6 @@ namespace API
 		return pimpl->LaunchPost(url, callback, post_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
 	}
 	
-	// NOTE: forwards to LaunchPostForm (no timeouts)
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
 		const std::vector<std::string>& post_ids,
 		const std::vector<std::string>& post_data, std::vector<std::string> headers)
@@ -502,7 +506,6 @@ namespace API
 		return pimpl->LaunchPostForm(url, callback, post_ids, post_data, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
 	}
 
-	// NOTE: forwards to LaunchPostForm (with timeouts)
 	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
 		const std::vector<std::string>& post_ids,
 		const std::vector<std::string>& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
@@ -557,7 +560,6 @@ namespace API
 		return true;
 	}
 	
-	// NOTE: forwards to LaunchPatch (default content_type "application/x-www-form-urlencoded", no timeouts)
 	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, std::vector<std::string> headers)
 	{
         auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
@@ -569,7 +571,6 @@ namespace API
 		return pimpl->LaunchPatch(url, callback, patch_data, "application/x-www-form-urlencoded", headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
 	}
 
-	// NOTE: forwards to LaunchPatch (explicit content_type, no timeouts)
 	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, const std::string &content_type, std::vector<std::string> headers)
 	{
         auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
@@ -581,7 +582,6 @@ namespace API
 		return pimpl->LaunchPatch(url, callback, patch_data, content_type, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
 	}
 
-	// NOTE: forwards to LaunchPatch (default content_type "application/x-www-form-urlencoded", with timeouts)
 	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
 	{
         auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
@@ -593,7 +593,6 @@ namespace API
 		return pimpl->LaunchPatch(url, callback, patch_data, "application/x-www-form-urlencoded", headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);	
 	}
 
-	// NOTE: forwards to LaunchPatch (explicit content_type, with timeouts)
 	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, const std::string &content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
 	{
         auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
@@ -636,7 +635,6 @@ namespace API
 		return true;
 	}
 
-	// NOTE: forwards to LaunchDelete (no timeouts)
 	bool Requests::CreateDeleteRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, std::vector<std::string> headers)
 	{
         auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
@@ -648,7 +646,6 @@ namespace API
 		return pimpl->LaunchDelete(url, callback, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
 	}
 
-	// NOTE: forwards to LaunchDelete (with timeouts)
 	bool Requests::CreateDeleteRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
 	{
         auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
@@ -658,6 +655,96 @@ namespace API
         }
 
 		return pimpl->LaunchDelete(url, callback, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);	
+	}
+
+	// ! --- DEPRECATED ---
+
+	bool Requests::CreatePostRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &post_data, std::vector<std::string> headers)
+	{
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of deprecated CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		auto adaptedCallback = DeprecatedCallbackAdapter(callback);
+
+		return pimpl->LaunchPost(url, adaptedCallback, post_data, "application/x-www-form-urlencoded", headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);
+	}
+
+	bool Requests::CreatePostRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of deprecated CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		auto adaptedCallback = DeprecatedCallbackAdapter(callback);
+
+		return pimpl->LaunchPost(url, adaptedCallback, post_data, "application/x-www-form-urlencoded", headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
+	}
+
+	bool Requests::CreatePostRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &post_data, const std::string &content_type, std::vector<std::string> headers)
+	{
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of deprecated CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		auto adaptedCallback = DeprecatedCallbackAdapter(callback);
+
+		return pimpl->LaunchPost(url, adaptedCallback, post_data, content_type, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);
+	}
+			
+	bool Requests::CreatePostRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &post_data, const std::string &content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of deprecated CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		auto adaptedCallback = DeprecatedCallbackAdapter(callback);
+
+		return pimpl->LaunchPost(url, adaptedCallback, post_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
+	}
+
+	bool Requests::CreatePostRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::vector<std::string> &post_ids, const std::vector<std::string> &post_data, std::vector<std::string> headers)
+	{
+		if (post_ids.size() != post_data.size()) {
+			Log::GetLog()->error( "Mismatched post_ids and post_data sizes in CreatePostRequest. Request cancelled.");
+			return false;
+		}
+		
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of deprecated CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		auto adaptedCallback = DeprecatedCallbackAdapter(callback);
+
+		return pimpl->LaunchPostForm(url, adaptedCallback, post_ids, post_data, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);
+	}
+
+	bool Requests::CreatePostRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::vector<std::string> &post_ids, const std::vector<std::string> &post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+		if (post_ids.size() != post_data.size()) {
+			Log::GetLog()->error( "Mismatched post_ids and post_data sizes in CreatePostRequest. Request cancelled.");
+			return false;
+		}
+
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of deprecated CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		auto adaptedCallback = DeprecatedCallbackAdapter(callback);
+
+		return pimpl->LaunchPostForm(url, adaptedCallback, post_ids, post_data, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
 	}
 
 	// --- UTILITY ---
@@ -740,7 +827,7 @@ namespace API
 		
 		for (auto& request : requests_temp) {
 			if (request.callbackId == 0) {
-				Log::GetLog()->critical("Received HTTP response with invalid callback ID 0. This is not supposed to happen. Report this to a maintainer. The response will be discarded and callback will not be invoked.");
+				Log::GetLog()->critical("Received HTTP response with invalid callback ID 0. This is not supposed to happen. Report this to a maintainer. The response will be discarded and the callback will not be invoked.");
 				continue;
 			}
 			

--- a/AsaApi/Core/Private/Tools/Requests.cpp
+++ b/AsaApi/Core/Private/Tools/Requests.cpp
@@ -1,19 +1,23 @@
-#pragma once
 #define WIN32_LEAN_AND_MEAN
 #pragma warning(push)
 #pragma warning(disable: 4191)
 #pragma warning(disable : 4996)
+
 #include <Requests.h>
-
 #include "../IBaseApi.h"
+#include "../Ark/ArkBaseApi.h"
 
-#include <sstream>
-
+#include <atomic>
+#include <fstream>
+#include <intrin.h>
 #include <mutex>
+#include <optional>
+#include <sstream>
+#include <unordered_map>
+#include <variant>
 
 #include "json.hpp"
 
-#include "fstream"
 #include "Poco/StreamCopier.h"
 #include "Poco/URI.h"
 #include "Poco/Exception.h"
@@ -33,42 +37,66 @@
 #include "Poco/Net/HTTPRequest.h"
 #include "Poco/Net/HTTPResponse.h"
 #include "Poco/Timespan.h"
-#include "../Ark/ArkBaseApi.h"
-#include <variant>
 
 namespace API
 {
+	namespace {
+		std::optional<HMODULE> TryGetModuleHandleFromAddress(void *address) 
+		{
+    		HMODULE HModule = nullptr;
+			
+			if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | 	GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCSTR)address, &HModule)) 
+			{
+        	return HModule;
+			}
+
+    		return std::nullopt;
+		}
+
+		using CallbackVariant = std::variant<std::function<void(bool, std::string)>, std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>>;
+	}  // namespace
+	
 	class Requests::impl
 	{
-	public:
-		void WriteRequest(std::function<void(bool, std::string)> callback, bool success, std::string result);
-		void WriteRequest(std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)> callback, bool success, std::string result, std::unordered_map<std::string, std::string> headers);
-
-		Poco::Net::HTTPRequest ConstructRequest(const std::string& url, Poco::Net::HTTPClientSession*& session,
-			const std::vector<std::string>& headers, const std::string& request_type, long connectionTimeout, long receiveTimeout, long sendTimeout);
-
-		std::string GetResponse(Poco::Net::HTTPClientSession* session, Poco::Net::HTTPResponse& response);
-		std::unordered_map<std::string, std::string> GetResponseHeaders(Poco::Net::HTTPResponse& response);
-
+		public:
+		uint64_t RegisterCallback(CallbackVariant callback, HMODULE callingPlugin);
+    	void EnqueueResult(std::string result, std::unordered_map<std::string, std::string> headers, uint64_t id, bool success);
+    	void EnqueueResult(std::string result, uint64_t id, bool success);
+		void UnregisterCallbacksForModule(HMODULE pluginModule);
+		
+    	bool LaunchGet(const std::string& url, const std::function<void(bool, std::string)>& callback, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule);
+    	bool LaunchPost(const std::string &url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)> &callback, const std::string &post_data, const std::string &content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule);
+    	bool LaunchPostForm(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback, const std::vector<std::string>& post_ids, const std::vector<std::string>& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule);
+    	bool LaunchPatch(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, const std::string &content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule);
+    	bool LaunchDelete(const std::string &url, const std::function<void(bool, std::string)> &callback, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule);
+		
+		Poco::Net::HTTPRequest ConstructRequest(const std::string& url, Poco::Net::HTTPClientSession*& session, const std::vector<std::string>& headers, const std::string& request_type, long connectionTimeout, long receiveTimeout, long sendTimeout);
+		std::string GetResponse(Poco::Net::HTTPClientSession* session, Poco::Net::HTTPResponse& response); std::unordered_map<std::string, std::string> GetResponseHeaders(Poco::Net::HTTPResponse& response);
 		void LogRequestError(const std::string& url, const Poco::Exception& exc);
-
+			
 		void Update();
-	private:
-		using CallbackVariant = std::variant<
-			std::function<void(bool, std::string)>,
-			std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>
-		>;
-		struct RequestData
-		{
-			CallbackVariant callback;
+		private:
+		struct RequestData {
 			bool success;
 			std::string result;
 			std::unordered_map<std::string, std::string> headers = std::unordered_map<std::string, std::string>();
+			uint64_t callbackId;
 		};
 
+		struct CallbackEntry {
+			CallbackVariant callback;
+		    HMODULE pluginModule;
+		};
+	
+
+    	std::unordered_map<uint64_t, CallbackEntry> CallbacksMap_;
 		std::vector<RequestData> RequestsVec_;
 		std::mutex RequestMutex_;
+		std::mutex CallbackMutex_;
+    	std::atomic<uint64_t> NextId_{1}; // 0 is an internal sentinel
 	};
+
+	// --- PIMPL ---
 
 	Requests::Requests()
 		: pimpl{ std::make_unique<impl>() }
@@ -96,18 +124,6 @@ namespace API
 	{
 		static Requests instance;
 		return instance;
-	}
-
-	void Requests::impl::WriteRequest(std::function<void(bool, std::string)> callback, bool success, std::string result)
-	{
-		std::lock_guard<std::mutex> Guard(RequestMutex_);
-		RequestsVec_.push_back({ callback, success, result });
-	}
-
-	void Requests::impl::WriteRequest(std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)> callback, bool success, std::string result, std::unordered_map<std::string, std::string> headers)
-	{
-		std::lock_guard<std::mutex> Guard(RequestMutex_);
-		RequestsVec_.push_back({ callback, success, result, headers });
 	}
 
 	void Requests::impl::LogRequestError(const std::string& url, const Poco::Exception& exc)
@@ -193,332 +209,96 @@ namespace API
 		return headers;
 	}
 
-	bool Requests::CreateGetRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		std::vector<std::string> headers)
+	void Requests::impl::EnqueueResult(std::string result, uint64_t callbackId, bool success) 
 	{
-		return CreateGetRequest(url, callback, headers, 0L, 0L, 0L);
+		std::lock_guard<std::mutex> Guard(RequestMutex_);
+	    RequestsVec_.push_back({success, std::move(result), {}, callbackId});
 	}
 
-	bool Requests::CreateGetRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	void Requests::impl::EnqueueResult(std::string result, std::unordered_map<std::string, std::string> headers, uint64_t callbackId, bool success) 
 	{
-		std::thread([this, url, callback, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
+		std::lock_guard<std::mutex> Guard(RequestMutex_);
+		RequestsVec_.push_back({success, std::move(result), std::move(headers), callbackId});
+	}
 
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_GET, connectionTimeout, receiveTimeout, sendTimeout);
+	uint64_t Requests::impl::RegisterCallback(CallbackVariant callback, HMODULE pluginModule)
+	{
+		std::lock_guard<std::mutex> Guard(CallbackMutex_);
+		const uint64_t callbackId = NextId_.fetch_add(1);
+		CallbacksMap_.emplace(callbackId, CallbackEntry{std::move(callback), pluginModule});
+		return callbackId;
+	}
 
-					session->sendRequest(request);
-					Result = pimpl->GetResponse(session, response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
+    void Requests::impl::UnregisterCallbacksForModule(HMODULE pluginModule)
+	{
+		std::lock_guard<std::mutex> Guard(CallbackMutex_);
+        size_t removed = std::erase_if(CallbacksMap_, [pluginModule](const auto& owner) {
+			return owner.second.pluginModule == pluginModule;
+        });
 
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
+		if (removed > 0) {
+			Log::GetLog()->debug("Drained {} pending HTTP request callbacks.", removed);
+		}
+	}
 
-				pimpl->WriteRequest(callback, success, Result);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
+	void Requests::UnregisterCallbacksForModule(HMODULE pluginModule)
+	{
+	    pimpl->UnregisterCallbacksForModule(pluginModule);
+	}
+
+    // --- GET REQUESTS ---
+
+    bool Requests::impl::LaunchGet(const std::string& url, const std::function<void(bool, std::string)>& callback, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule)
+	{
+		const uint64_t callbackId = RegisterCallback(callback, pluginModule);
+
+    	std::thread([this, url, headers, connectionTimeout, receiveTimeout, sendTimeout, suppressErrors, callbackId] {
+    	    std::string Result = "";
+    	    Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+    	    Poco::Net::HTTPClientSession *session = nullptr;
+
+    	    try {
+    	        Poco::Net::HTTPRequest &&request =
+    	            ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_GET, 	connectionTimeout, receiveTimeout, sendTimeout);
+
+    	        session->sendRequest(request);
+    	        Result = GetResponse(session, response);
+    	    } catch (const Poco::Exception &exc) {
+    	        if (!suppressErrors) LogRequestError(url, exc);
+    	    }
+
+    	    const bool success = (int)response.getStatus() >= 200 && (int)response.getStatus() < 300;
+
+    	    EnqueueResult(std::move(Result), callbackId, success);
+    	    delete session;
+    	    session = nullptr;
+    	}).detach();
 
 		return true;
 	}
 
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
-		const std::string& post_data, std::vector<std::string> headers)
+	bool Requests::CreateGetRequest(const std::string& url, const std::function<void(bool, std::string)>& callback, std::vector<std::string> headers)
 	{
-		return CreatePostRequest(url, callback, post_data, headers, 0L, 0L, 0L);
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+	    if (!HModuleOpt) {
+	        Log::GetLog()->error(
+	            "Failed to get module handle for caller of CreateGetRequest. Request cancelled. Error code: {}", GetLastError());
+	        return false;
+	    }
+
+		return pimpl->LaunchGet(url, callback, headers, 0, 0, 0, suppress_errors, *HModuleOpt);
 	}
 
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
-		const std::string& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	bool Requests::CreateGetRequest(const std::string& url, const std::function<void(bool, std::string)>& callback, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
 	{
-		std::thread([this, url, callback, post_data, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				std::unordered_map<std::string, std::string> responseHeaders;
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
+		auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+	    if (!HModuleOpt) {
+	        Log::GetLog()->error(
+	            "Failed to get module handle for caller of CreateGetRequest. Request cancelled. Error code: {}", GetLastError());
+	        return false;
+	    }
 
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, connectionTimeout, receiveTimeout, sendTimeout);
-
-					request.setContentType("application/x-www-form-urlencoded");
-					request.setContentLength(post_data.length());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << post_data;
-
-					Result = pimpl->GetResponse(session, response);
-					responseHeaders = pimpl->GetResponseHeaders(response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result, responseHeaders);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
-	}
-
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback, const std::string& post_data, const std::string& content_type, std::vector<std::string> headers)
-	{
-		return CreatePostRequest(url, callback, post_data, content_type, headers, 0L, 0L, 0L);
-	}
-
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
-		const std::string& post_data, const std::string& content_type, std::vector<std::string> headers,
-		long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		std::thread([this, url, callback, post_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				std::unordered_map<std::string, std::string> responseHeaders;
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, connectionTimeout, receiveTimeout, sendTimeout);
-
-					request.setContentType(content_type);
-					request.setContentLength(post_data.length());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << post_data;
-
-					Result = pimpl->GetResponse(session, response);
-					responseHeaders = pimpl->GetResponseHeaders(response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result, responseHeaders);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
-	}
-
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
-		const std::vector<std::string>& post_ids,
-		const std::vector<std::string>& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		if (post_ids.size() != post_data.size())
-			return false;
-
-		std::thread([this, url, callback, post_ids, post_data, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				std::unordered_map<std::string, std::string> responseHeaders;
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, connectionTimeout, receiveTimeout, sendTimeout);
-
-					std::string body;
-
-					for (size_t i = 0; i < post_ids.size(); ++i)
-					{
-						const std::string& id = post_ids[i];
-						const std::string& data = post_data[i];
-
-						body += fmt::format("{}={}&", Poco::UTF8::escape(id), Poco::UTF8::escape(data));
-					}
-
-					body.pop_back(); // Remove last '&'
-
-					request.setContentType("application/x-www-form-urlencoded");
-					request.setContentLength(body.size());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << body;
-
-					Result = pimpl->GetResponse(session, response);
-					responseHeaders = pimpl->GetResponseHeaders(response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result, responseHeaders);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
-	}
-
-	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
-		const std::vector<std::string>& post_ids,
-		const std::vector<std::string>& post_data, std::vector<std::string> headers)
-	{
-		return CreatePostRequest(url, callback, post_ids, post_data, headers, 0L, 0L, 0L);
-	}
-
-	bool Requests::CreatePatchRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::string& patch_data, std::vector<std::string> headers)
-	{
-		return CreatePatchRequest(url, callback, patch_data, headers, 0L, 0L, 0L);
-	}
-
-	bool Requests::CreatePatchRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::string& patch_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		std::thread([this, url, callback, patch_data, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_PATCH, connectionTimeout, receiveTimeout, sendTimeout);
-
-					request.setContentType("application/x-www-form-urlencoded");
-					request.setContentLength(patch_data.length());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << patch_data;
-
-					Result = pimpl->GetResponse(session, response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
-	}
-
-	bool Requests::CreatePatchRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::string& patch_data, const std::string& content_type, std::vector<std::string> headers)
-	{
-		return CreatePatchRequest(url, callback, patch_data, content_type, headers, 0L, 0L, 0L);
-	}
-
-	bool Requests::CreatePatchRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		const std::string& patch_data, const std::string& content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		std::thread([this, url, callback, patch_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_PATCH, connectionTimeout, receiveTimeout, sendTimeout);
-
-					request.setContentType(content_type);
-					request.setContentLength(patch_data.length());
-
-					std::ostream& OutputStream = session->sendRequest(request);
-					OutputStream << patch_data;
-
-					Result = pimpl->GetResponse(session, response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
-	}
-
-	bool Requests::CreateDeleteRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		std::vector<std::string> headers)
-	{
-		return CreateDeleteRequest(url, callback, headers, 0L, 0L, 0L);
-	}
-
-	bool Requests::CreateDeleteRequest(const std::string& url, const std::function<void(bool, std::string)>& callback,
-		std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
-	{
-		std::thread([this, url, callback, headers, connectionTimeout, receiveTimeout, sendTimeout]
-			{
-				std::string Result = "";
-				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
-				Poco::Net::HTTPClientSession* session = nullptr;
-
-				try
-				{
-					Poco::Net::HTTPRequest&& request = pimpl->ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_DELETE, connectionTimeout, receiveTimeout, sendTimeout);
-
-					session->sendRequest(request);
-					Result = pimpl->GetResponse(session, response);
-				}
-				catch (const Poco::Exception& exc)
-				{
-					if (!suppress_errors)
-						pimpl->LogRequestError(url, exc);
-				}
-
-				const bool success = (int)response.getStatus() >= 200
-					&& (int)response.getStatus() < 300;
-
-				pimpl->WriteRequest(callback, success, Result);
-				delete session;
-				session = nullptr;
-			}
-		).detach();
-
-		return true;
+		return pimpl->LaunchGet(url, callback, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
 	}
 
 	Requests::RequestSyncData Requests::CreateGetRequestSync(const std::string& url,
@@ -556,6 +336,331 @@ namespace API
 
 		return Result;
 	}
+
+	// --- POST REQUESTS ---
+
+	bool Requests::impl::LaunchPost(const std::string &url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)> &callback, const std::string &post_data, const std::string &content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule) 
+	{
+		const uint64_t callbackId = RegisterCallback(callback, pluginModule);
+
+    	std::thread(
+    	    [this, url, post_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout, 	suppressErrors, callbackId] {
+    	    std::string Result = "";
+    	    std::unordered_map<std::string, std::string> responseHeaders;
+    	    Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+    	    Poco::Net::HTTPClientSession *session = nullptr;
+
+    		try {
+    		    Poco::Net::HTTPRequest &&request =
+    		        ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, 	connectionTimeout, receiveTimeout, sendTimeout);
+					
+    		    request.setContentType(content_type);
+    		    request.setContentLength(post_data.length());
+					
+    		    std::ostream & OutputStream = session->sendRequest(request);
+    		    OutputStream << post_data;
+					
+    		    Result          = GetResponse(session, response);
+    		    responseHeaders = GetResponseHeaders(response);
+    		} catch (const Poco::Exception &exc) {
+    		    if (!suppressErrors) LogRequestError(url, exc);
+    		}
+		
+    		const bool success = (int)response.getStatus() >= 200 && (int)response.getStatus() < 300;
+		
+    		EnqueueResult(std::move(Result), std::move(responseHeaders), callbackId, success);
+    		delete session;
+    		session = nullptr;
+    	}).detach();
+
+		return true;
+	}
+
+	bool Requests::impl::LaunchPostForm(const std::string &url, const std::function<void(bool,std::string, std::unordered_map<std::string, std::string>)> &callback, const std::vector<std::string> &post_ids, const std::vector<std::string> &post_data,std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout,bool suppressErrors, HMODULE pluginModule) 
+	{
+		const uint64_t callbackId = RegisterCallback(callback, pluginModule);
+
+		std::thread([this, url, post_ids, post_data, headers, connectionTimeout, receiveTimeout, sendTimeout, suppressErrors, callbackId] {
+				std::string Result = "";
+				std::unordered_map<std::string, std::string> responseHeaders;
+				Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+				Poco::Net::HTTPClientSession* session = nullptr;
+
+				try
+				{
+					Poco::Net::HTTPRequest&& request = ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_POST, connectionTimeout, receiveTimeout, sendTimeout);
+
+					std::string body = "";
+
+					for (size_t i = 0; i < post_ids.size(); ++i)
+					{
+						const std::string& id = post_ids[i];
+						const std::string& data = post_data[i];
+
+						body += fmt::format("{}={}&", Poco::UTF8::escape(id), Poco::UTF8::escape(data));
+					}
+
+					if (!body.empty()) {
+						body.pop_back(); // Remove last '&'
+					}
+
+					request.setContentType("application/x-www-form-urlencoded");
+					request.setContentLength(body.size());
+
+					std::ostream& OutputStream = session->sendRequest(request);
+					OutputStream << body;
+
+					Result = GetResponse(session, response);
+					responseHeaders = GetResponseHeaders(response);
+				}
+				catch (const Poco::Exception& exc)
+				{
+					if (!suppressErrors)
+						LogRequestError(url, exc);
+				}
+
+				const bool success = (int)response.getStatus() >= 200
+					&& (int)response.getStatus() < 300;
+
+				EnqueueResult(std::move(Result), std::move(responseHeaders), callbackId, success);
+				delete session;
+				session = nullptr;
+			}
+		).detach();
+
+		return true;
+	}
+
+	// NOTE: forwards to LaunchPost (default content_type "application/x-www-form-urlencoded", no timeouts)
+	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
+		const std::string& post_data, std::vector<std::string> headers)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPost(url, callback, post_data, "application/x-www-form-urlencoded", headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);
+	}
+
+	// NOTE: forwards to LaunchPost (explicit content_type, no timeouts)
+	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback, const std::string& post_data, const std::string& content_type, std::vector<std::string> headers)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPost(url, callback, post_data, content_type, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);
+	}
+
+	// NOTE: forwards to LaunchPost (default content_type "application/x-www-form-urlencoded", with timeouts)
+	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
+		const std::string& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPost(url, callback, post_data, "application/x-www-form-urlencoded", headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
+	}
+
+	// NOTE: forwards to LaunchPost (explicit content_type, with timeouts)
+	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
+		const std::string& post_data, const std::string& content_type, std::vector<std::string> headers,
+		long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPost(url, callback, post_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);
+	}
+	
+	// NOTE: forwards to LaunchPostForm (no timeouts)
+	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
+		const std::vector<std::string>& post_ids,
+		const std::vector<std::string>& post_data, std::vector<std::string> headers)
+	{
+		if (post_ids.size() != post_data.size()) {
+			Log::GetLog()->error( "Mismatched post_ids and post_data sizes in CreatePostRequest. Request cancelled.");
+			return false;
+		}
+
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPostForm(url, callback, post_ids, post_data, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
+	}
+
+	// NOTE: forwards to LaunchPostForm (with timeouts)
+	bool Requests::CreatePostRequest(const std::string& url, const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
+		const std::vector<std::string>& post_ids,
+		const std::vector<std::string>& post_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+		if (post_ids.size() != post_data.size()) {
+			Log::GetLog()->error( "Mismatched post_ids and post_data sizes in CreatePostRequest. Request cancelled.");
+			return false;
+		}
+
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePostRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPostForm(url, callback, post_ids, post_data, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);	
+	}
+
+	// --- PATCH REQUESTS ---
+
+	bool Requests::impl::LaunchPatch(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, const std::string &content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule) {
+		const uint64_t callbackId = RegisterCallback(callback, pluginModule);
+
+	    std::thread([this, url, patch_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout, suppressErrors, callbackId] {
+	        std::string Result = "";
+	        Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+	        Poco::Net::HTTPClientSession *session = nullptr;
+
+	        try {
+	            Poco::Net::HTTPRequest &&request =
+	                ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_PATCH, 	connectionTimeout,
+	                                        receiveTimeout, sendTimeout);
+
+	            request.setContentType(content_type);
+	            request.setContentLength(patch_data.length());
+
+	            std::ostream &OutputStream = session->sendRequest(request);
+	            OutputStream << patch_data;
+
+	            Result = GetResponse(session, response);
+	        } catch (const Poco::Exception &exc) {
+	            if (!suppressErrors) LogRequestError(url, exc);
+	        }
+
+	        const bool success = (int)response.getStatus() >= 200 && (int)response.getStatus() < 300;
+
+	        EnqueueResult(std::move(Result), callbackId, success);
+	        delete session;
+	        session = nullptr;
+	    }).detach();
+
+		return true;
+	}
+	
+	// NOTE: forwards to LaunchPatch (default content_type "application/x-www-form-urlencoded", no timeouts)
+	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, std::vector<std::string> headers)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePatchRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPatch(url, callback, patch_data, "application/x-www-form-urlencoded", headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
+	}
+
+	// NOTE: forwards to LaunchPatch (explicit content_type, no timeouts)
+	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, const std::string &content_type, std::vector<std::string> headers)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePatchRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPatch(url, callback, patch_data, content_type, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
+	}
+
+	// NOTE: forwards to LaunchPatch (default content_type "application/x-www-form-urlencoded", with timeouts)
+	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePatchRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPatch(url, callback, patch_data, "application/x-www-form-urlencoded", headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);	
+	}
+
+	// NOTE: forwards to LaunchPatch (explicit content_type, with timeouts)
+	bool Requests::CreatePatchRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, const std::string &patch_data, const std::string &content_type, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreatePatchRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchPatch(url, callback, patch_data, content_type, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);	
+	}
+
+	// --- DELETE REQUESTS ---
+
+	bool Requests::impl::LaunchDelete(const std::string &url, const std::function<void(bool, std::string)> &callback, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout, bool suppressErrors, HMODULE pluginModule)
+	{
+		const uint64_t callbackId = RegisterCallback(callback, pluginModule);
+
+	    std::thread([this, url, headers, connectionTimeout, receiveTimeout, sendTimeout, suppressErrors, callbackId] {
+	        std::string Result = "";
+	        Poco::Net::HTTPResponse response(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+	        Poco::Net::HTTPClientSession *session = nullptr;
+
+	        try {
+	            Poco::Net::HTTPRequest &&request =
+	                ConstructRequest(url, session, headers, Poco::Net::HTTPRequest::HTTP_DELETE, connectionTimeout, receiveTimeout, sendTimeout);
+
+	            session->sendRequest(request);
+	            Result = GetResponse(session, response);
+	        } catch (const Poco::Exception &exc) {
+	            if (!suppressErrors) LogRequestError(url, exc);
+	        }
+
+	        const bool success = (int)response.getStatus() >= 200 && (int)response.getStatus() < 300;
+
+	        EnqueueResult(std::move(Result), callbackId, success);
+	        delete session;
+	        session = nullptr;
+	    }).detach();		
+
+		return true;
+	}
+
+	// NOTE: forwards to LaunchDelete (no timeouts)
+	bool Requests::CreateDeleteRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, std::vector<std::string> headers)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreateDeleteRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchDelete(url, callback, headers, 0L, 0L, 0L, suppress_errors, *HModuleOpt);	
+	}
+
+	// NOTE: forwards to LaunchDelete (with timeouts)
+	bool Requests::CreateDeleteRequest(const std::string &url, const std::function<void(bool, std::string)> &callback, std::vector<std::string> headers, long connectionTimeout, long receiveTimeout, long sendTimeout)
+	{
+        auto HModuleOpt = TryGetModuleHandleFromAddress(_ReturnAddress());
+        if (!HModuleOpt) {
+            Log::GetLog()->error( "Failed to get module handle for caller of CreateDeleteRequest. Request cancelled. Error code: {}", GetLastError());
+            return false;
+        }
+
+		return pimpl->LaunchDelete(url, callback, headers, connectionTimeout, receiveTimeout, sendTimeout, suppress_errors, *HModuleOpt);	
+	}
+
+	// --- UTILITY ---
 
 	bool Requests::DownloadFile(const std::string& url, const std::string& localPath, std::vector<std::string> headers)
 	{
@@ -623,25 +728,49 @@ namespace API
 		return true;
 	}
 
-	void Requests::impl::Update()
-	{
-		if (RequestsVec_.empty())
-			return;
-
-		RequestMutex_.lock();
-		std::vector<RequestData> requests_temp = std::move(RequestsVec_);
-		RequestMutex_.unlock();
-
-		for (const auto& request : requests_temp)
+	void Requests::impl::Update() {
+		std::vector<RequestData> requests_temp;
 		{
-			std::visit([&](auto&& callback)
-				{
-					using T = std::decay_t<decltype(callback)>;
-					if constexpr (std::is_same_v<T, std::function<void(bool, std::string)>>)
-						callback(request.success, request.result);
-					else if constexpr (std::is_same_v<T, std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>>)
-						callback(request.success, request.result, request.headers);
-				}, request.callback);
+			std::lock_guard<std::mutex> lock(RequestMutex_);
+			if (RequestsVec_.empty()) {
+				return;
+			}
+			requests_temp = std::move(RequestsVec_);
+		}
+		
+		for (auto& request : requests_temp) {
+			if (request.callbackId == 0) {
+				Log::GetLog()->critical("Received HTTP response with invalid callback ID 0. This is not supposed to happen. Report this to a maintainer. The response will be discarded and callback will not be invoked.");
+				continue;
+			}
+			
+			CallbackVariant callback;
+			{
+				std::lock_guard<std::mutex> lock(CallbackMutex_);
+				auto it = CallbacksMap_.find(request.callbackId);
+				
+				if (it == CallbacksMap_.end()) {
+					Log::GetLog()->debug("Received HTTP response for unknown request ID {}. This likely means the owning plugin was unloaded before the response was received. The callback will not be invoked.", request.callbackId);
+					continue;
+				}
+			
+				callback = std::move(it->second.callback);
+				CallbacksMap_.erase(it);
+			}
+			
+			// Safe to invoke unlocked: `PluginManager::UnloadPlugin` runs on the game thread, same as Update().
+			// Caveat: self-unload from inside a callback is unsupported.
+			std::visit([&](auto&& cb) {
+				using T = std::decay_t<decltype(cb)>;
+				
+				if constexpr (std::is_same_v<T, std::function<void(bool, std::string)>>){
+					cb(request.success, std::move(request.result));
+				} else if constexpr (std::is_same_v<T, std::function<void(bool, std::string,std::unordered_map<std::string, std::string>)>>) {
+					cb(request.success, std::move(request.result), std::move(request.headers));
+				}
+				
+			}, callback); 
 		}
 	}
+
 } // namespace API

--- a/AsaApi/Core/Public/Requests.h
+++ b/AsaApi/Core/Public/Requests.h
@@ -42,7 +42,7 @@ namespace API
 		/**
 		 * \brief Creates an async GET Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param included headers
 		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
@@ -55,7 +55,7 @@ namespace API
 		 * \brief Creates an async GET Request that runs in another thread but calls the callback from the main thread, with
 		 * timeout options
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
@@ -72,7 +72,7 @@ namespace API
 		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another
 		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * \param the callback function, binds success(bool), result(string) and ,
 		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
 		 * response otherwise
 		 * \param data to post
@@ -88,7 +88,7 @@ namespace API
 		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another
 		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * \param the callback function, binds success(bool), result(string) and ,
 		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
 		 * response otherwise
 		 * \param data to post
@@ -107,7 +107,7 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * \param the callback function, binds success(bool), result(string) and ,
 		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
 		 * response otherwise
 		 * \param data to post
@@ -124,7 +124,7 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * \param the callback function, binds success(bool), result(string) and ,
 		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
 		 * response otherwise
 		 * \param data to post
@@ -145,7 +145,7 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * \param the callback function, binds success(bool), result(string) and ,
 		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
 		 * response otherwise
 		 * \param data key
@@ -162,7 +162,7 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * \param the callback function, binds success(bool), result(string) and ,
 		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
 		 * response otherwise
 		 * \param data key
@@ -184,7 +184,7 @@ namespace API
 		 * \brief Creates an async PATCH Request with application/x-www-form-urlencoded content type that runs in another
 		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param data to patch
 		 * \param included headers
@@ -199,7 +199,7 @@ namespace API
 		 * \brief Creates an async PATCH Request with application/x-www-form-urlencoded content type that runs in another
 		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param data to patch
 		 * \param included headers
@@ -217,7 +217,7 @@ namespace API
 		/**
 		 * \brief Creates an async PATCH Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param data to patch
 		 * \param content type
@@ -233,7 +233,7 @@ namespace API
 		/**
 		 * \brief Creates an async PATCH Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param data to patch
 		 * \param content type
@@ -253,7 +253,7 @@ namespace API
 		/**
 		 * \brief Creates an async DELETE Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param included headers
 		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
@@ -265,7 +265,7 @@ namespace API
 		/**
 		 * \brief Creates an async DELETE Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and
 		 * the response otherwise
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
@@ -310,6 +310,121 @@ namespace API
 		 * \return `true` if the file was successfully downloaded, `false` otherwise
 		 */
 		static bool DownloadFile(const std::string& url, const std::string& localPath, std::vector<std::string> headers = {});
+
+		// ! --- DEPRECATED ---
+		// NOTE: These functions are deprecated. They are intentionally left in place to maintain backward compatibility 
+		// with existing deployed plugins. Do not use in new code. Consider migrating existing usage to the non-deprecated versions.
+
+		/**
+		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
+		 * \deprecated Use the 3-arg callback variant for explicit response-header access.
+		 * \param request URL
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param data to post
+		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
+		 */
+		[[deprecated("Use the 3-arg callback variant for explicit response-header access")]]
+		ARK_API bool CreatePostRequest(const std::string& url,
+			const std::function<void(bool, std::string)>& callback,
+			const std::string& post_data,
+			std::vector<std::string> headers = {});		
+
+		/**
+		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
+		 * \deprecated Use the 3-arg callback variant for explicit response-header access.
+		 * \param request URL
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param data to post
+		 * \param included headers
+		 * \param included connectionTimeout in seconds (0 = default)
+		 * \param included receiveTimeout in seconds (0 = default)
+		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
+		 */
+		[[deprecated("Use the 3-arg callback variant for explicit response-header access")]]
+		ARK_API bool CreatePostRequest(const std::string& url,
+			const std::function<void(bool, std::string)>& callback,
+			const std::string& post_data,
+			std::vector<std::string> headers,
+			long connectionTimeout, long receiveTimeout, long sendTimeout);
+
+		/**
+		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
+		 * \deprecated Use the 3-arg callback variant for explicit response-header access.
+		 * \param request URL
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param data to post
+		 * \param content type
+		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
+		 */
+		[[deprecated("Use the 3-arg callback variant for explicit response-header access")]]
+		ARK_API bool CreatePostRequest(const std::string& url,
+			const std::function<void(bool, std::string)>& callback,
+			const std::string& post_data,
+			const std::string& content_type,
+			std::vector<std::string> headers = {});
+			
+		/**
+		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
+		 * \deprecated Use the 3-arg callback variant for explicit response-header access.
+		 * \param request URL
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param data to post
+		 * \param content type
+		 * \param included headers
+		 * \param included connectionTimeout in seconds (0 = default)
+		 * \param included receiveTimeout in seconds (0 = default)
+		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
+		 */
+		[[deprecated("Use the 3-arg callback variant for explicit response-header access")]]
+		ARK_API bool CreatePostRequest(const std::string& url,
+			const std::function<void(bool, std::string)>& callback,
+			const std::string& post_data,
+			const std::string& content_type,
+			std::vector<std::string> headers,
+			long connectionTimeout, long receiveTimeout, long sendTimeout);			
+
+		/**
+		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
+		 * \deprecated Use the 3-arg callback variant for explicit response-header access.
+		 * \param request URL
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param data key
+		 * \param data value
+		 * \param included headers
+		 * \return `true` on dispatch, `false` if data sizes are mismatched or the caller's plugin module could not be resolved.
+		 */
+		[[deprecated("Use the 3-arg callback variant for explicit response-header access")]]
+		ARK_API bool CreatePostRequest(const std::string& url,
+			const std::function<void(bool, std::string)>& callback,
+			const std::vector<std::string>& post_ids,
+			const std::vector<std::string>& post_data,
+			std::vector<std::string> headers = {});
+
+		/**
+		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
+		 * \deprecated Use the 3-arg callback variant for explicit response-header access.
+		 * \param request URL
+		 * \param the callback function, binds success(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param data key
+		 * \param data value
+		 * \param included headers
+		 * \param included connectionTimeout in seconds (0 = default)
+		 * \param included receiveTimeout in seconds (0 = default)
+		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if data sizes are mismatched or the caller's plugin module could not be resolved.
+		 */
+		[[deprecated("Use the 3-arg callback variant for explicit response-header access")]]
+		ARK_API bool CreatePostRequest(const std::string& url,
+			const std::function<void(bool, std::string)>& callback,
+			const std::vector<std::string>& post_ids,
+			const std::vector<std::string>& post_data,
+			std::vector<std::string> headers,
+			long connectionTimeout, long receiveTimeout, long sendTimeout);
+
 
 	private:
 		class impl;

--- a/AsaApi/Core/Public/Requests.h
+++ b/AsaApi/Core/Public/Requests.h
@@ -3,8 +3,8 @@
 #include <functional>
 #include <vector>
 #include <mutex>
+#include <windows.h>
 #include "API/Base.h"
-
 
 namespace API
 {
@@ -27,25 +27,41 @@ namespace API
 			std::string result;
 		};
 
+		/**
+		 * \brief Discards all pending HTTP request callbacks owned by the specified plugin module.
+		 *
+		 * - Must be called before `FreeLibrary` for the plugin.
+		 * - No callback registered by this module will be invoked on subsequent ticks.
+		 * - Worker threads still in flight for this module are unaffected. Their results
+		 *   will be silently discarded when `Update()` finds no matching callback id.
+		 * - Thread-safe. Acquires an internal callback registry mutex.
+		 * \param pluginModule Handle of the plugin being unloaded.
+		 */
+		ARK_API void UnregisterCallbacksForModule(HMODULE pluginModule);
 
 		/**
 		 * \brief Creates an async GET Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreateGetRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
 			std::vector<std::string> headers = {});
 
 		/**
-		 * \brief Creates an async GET Request that runs in another thread but calls the callback from the main thread, with timeout options
+		 * \brief Creates an async GET Request that runs in another thread but calls the callback from the main thread, with
+		 * timeout options
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreateGetRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
@@ -53,11 +69,15 @@ namespace API
 			long connectionTimeout, long receiveTimeout, long sendTimeout);
 
 		/**
-		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
+		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another
+		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
+		 * response otherwise
 		 * \param data to post
 		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePostRequest(const std::string& url,
 			const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
@@ -65,14 +85,18 @@ namespace API
 			std::vector<std::string> headers = {});
 
 		/**
-		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
+		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another
+		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
+		 * response otherwise
 		 * \param data to post
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePostRequest(const std::string& url,
 			const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
@@ -83,10 +107,13 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
+		 * response otherwise
 		 * \param data to post
 		 * \param content type
 		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePostRequest(const std::string& url,
 			const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
@@ -97,13 +124,16 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
+		 * response otherwise
 		 * \param data to post
 		 * \param content type
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePostRequest(const std::string& url,
 			const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
@@ -115,10 +145,13 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
+		 * response otherwise
 		 * \param data key
 		 * \param data value
 		 * \param included headers
+		 * \return `true` on dispatch, `false` if data sizes are mismatched or the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePostRequest(const std::string& url,
 			const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
@@ -129,13 +162,16 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool), result(string) and ,
+		 * responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the
+		 * response otherwise
 		 * \param data key
 		 * \param data value
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if data sizes are mismatched or the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePostRequest(const std::string& url,
 			const std::function<void(bool, std::string, std::unordered_map<std::string, std::string>)>& callback,
@@ -145,11 +181,14 @@ namespace API
 			long connectionTimeout, long receiveTimeout, long sendTimeout);
 
 		/**
-		 * \brief Creates an async PATCH Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
+		 * \brief Creates an async PATCH Request with application/x-www-form-urlencoded content type that runs in another
+		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param data to patch
 		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePatchRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
@@ -157,14 +196,17 @@ namespace API
 			std::vector<std::string> headers = {});
 
 		/**
-		 * \brief Creates an async PATCH Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
+		 * \brief Creates an async PATCH Request with application/x-www-form-urlencoded content type that runs in another
+		 * thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param data to patch
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePatchRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
@@ -175,10 +217,12 @@ namespace API
 		/**
 		 * \brief Creates an async PATCH Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param data to patch
 		 * \param content type
 		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePatchRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
@@ -189,13 +233,15 @@ namespace API
 		/**
 		 * \brief Creates an async PATCH Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param data to patch
 		 * \param content type
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreatePatchRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
@@ -207,8 +253,10 @@ namespace API
 		/**
 		 * \brief Creates an async DELETE Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param included headers
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreateDeleteRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
@@ -217,11 +265,13 @@ namespace API
 		/**
 		 * \brief Creates an async DELETE Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
+		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and
+		 * the response otherwise
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return `true` on dispatch, `false` if the caller's plugin module could not be resolved.
 		 */
 		ARK_API bool CreateDeleteRequest(const std::string& url,
 			const std::function<void(bool, std::string)>& callback,
@@ -229,26 +279,38 @@ namespace API
 			long connectionTimeout, long receiveTimeout, long sendTimeout);
 
 		/**
-		 * \brief Creates an sync GET Request that should NOT be called from the main game thread to avoid player timeout issues
+		 * \brief Creates an sync GET Request that should NOT be called from the main game thread to avoid player timeout
+		 * issues
 		 * \param request URL
 		 * \param included headers
+		 * \return Populated `RequestSyncData` describing the response.
 		 */
 		ARK_API RequestSyncData CreateGetRequestSync(const std::string& url,
 			std::vector<std::string> headers = {});
 
 		/**
-		 * \brief Creates an sync GET Request that should NOT be called from the main game thread to avoid player timeout issues
+		 * \brief Creates an sync GET Request that should NOT be called from the main game thread to avoid player timeout
+		 * issues
 		 * \param request URL
 		 * \param included headers
 		 * \param included connectionTimeout in seconds (0 = default)
 		 * \param included receiveTimeout in seconds (0 = default)
 		 * \param included sendTimeout in seconds (0 = default)
+		 * \return Populated `RequestSyncData` describing the response.
 		 */
 		ARK_API RequestSyncData CreateGetRequestSync(const std::string& url,
 			std::vector<std::string> headers,
 			long connectionTimeout, long receiveTimeout, long sendTimeout);
 
+		/**
+		 * \brief Downloads a file from the specified URL to the specified local path, blocking the calling thread until completion.
+		 * \param url URL of the file to download
+		 * \param localPath Local file path to save the downloaded file to
+		 * \param headers Optional HTTP headers to include in the download request
+		 * \return `true` if the file was successfully downloaded, `false` otherwise
+		 */
 		static bool DownloadFile(const std::string& url, const std::string& localPath, std::vector<std::string> headers = {});
+
 	private:
 		class impl;
 		std::unique_ptr<impl> pimpl;

--- a/AsaApi/Core/Public/Requests.h
+++ b/AsaApi/Core/Public/Requests.h
@@ -55,19 +55,6 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
-		 * \param data to post
-		 * \param included headers
-		 */
-		[[deprecated]]
-		ARK_API bool CreatePostRequest(const std::string& url,
-			const std::function<void(bool, std::string)>& callback,
-			const std::string& post_data,
-			std::vector<std::string> headers = {});
-
-		/**
-		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
-		 * \param request URL
 		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
 		 * \param data to post
 		 * \param included headers
@@ -80,24 +67,6 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
-		 * \param data to post
-		 * \param included headers
-		 * \param included connectionTimeout in seconds (0 = default)
-		 * \param included receiveTimeout in seconds (0 = default)
-		 * \param included sendTimeout in seconds (0 = default)
-		 */
-		[[deprecated]]
-		ARK_API bool CreatePostRequest(const std::string& url,
-			const std::function<void(bool, std::string)>& callback,
-			const std::string& post_data,
-			std::vector<std::string> headers,
-			long connectionTimeout, long receiveTimeout, long sendTimeout);
-
-
-		/**
-		 * \brief Creates an async POST Request with application/x-www-form-urlencoded content type that runs in another thread but calls the callback from the main thread
-		 * \param request URL
 		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
 		 * \param data to post
 		 * \param included headers
@@ -110,21 +79,6 @@ namespace API
 			const std::string& post_data,
 			std::vector<std::string> headers,
 			long connectionTimeout, long receiveTimeout, long sendTimeout);
-
-		/**
-		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
-		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
-		 * \param data to post
-		 * \param content type
-		 * \param included headers
-		 */
-		[[deprecated]]
-		ARK_API bool CreatePostRequest(const std::string& url,
-			const std::function<void(bool, std::string)>& callback,
-			const std::string& post_data,
-			const std::string& content_type,
-			std::vector<std::string> headers = {});
 
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
@@ -143,25 +97,6 @@ namespace API
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
 		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
-		 * \param data to post
-		 * \param content type
-		 * \param included headers
-		 * \param included connectionTimeout in seconds (0 = default)
-		 * \param included receiveTimeout in seconds (0 = default)
-		 * \param included sendTimeout in seconds (0 = default)
-		 */
-		[[deprecated]]
-		ARK_API bool CreatePostRequest(const std::string& url,
-			const std::function<void(bool, std::string)>& callback,
-			const std::string& post_data,
-			const std::string& content_type,
-			std::vector<std::string> headers,
-			long connectionTimeout, long receiveTimeout, long sendTimeout);
-
-		/**
-		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
-		 * \param request URL
 		 * \param the callback function, binds sucess(bool), result(string) and , responseHeaders(std::unordered_map<std::string, std::string>), result is error code if request failed and the response otherwise
 		 * \param data to post
 		 * \param content type
@@ -176,21 +111,6 @@ namespace API
 			const std::string& content_type,
 			std::vector<std::string> headers,
 			long connectionTimeout, long receiveTimeout, long sendTimeout);
-
-		/**
-		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
-		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
-		 * \param data key
-		 * \param data value
-		 * \param included headers
-		 */
-		[[deprecated]]
-		ARK_API bool CreatePostRequest(const std::string& url,
-			const std::function<void(bool, std::string)>& callback,
-			const std::vector<std::string>& post_ids,
-			const std::vector<std::string>& post_data,
-			std::vector<std::string> headers = {});
 
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
@@ -205,25 +125,6 @@ namespace API
 			const std::vector<std::string>& post_ids,
 			const std::vector<std::string>& post_data,
 			std::vector<std::string> headers = {});
-
-		/**
-		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread
-		 * \param request URL
-		 * \param the callback function, binds sucess(bool) and result(string), result is error code if request failed and the response otherwise
-		 * \param data key
-		 * \param data value
-		 * \param included headers
-		 * \param included connectionTimeout in seconds (0 = default)
-		 * \param included receiveTimeout in seconds (0 = default)
-		 * \param included sendTimeout in seconds (0 = default)
-		 */
-		[[deprecated]]
-		ARK_API bool CreatePostRequest(const std::string& url,
-			const std::function<void(bool, std::string)>& callback,
-			const std::vector<std::string>& post_ids,
-			const std::vector<std::string>& post_data,
-			std::vector<std::string> headers,
-			long connectionTimeout, long receiveTimeout, long sendTimeout);
 
 		/**
 		 * \brief Creates an async POST Request that runs in another thread but calls the callback from the main thread


### PR DESCRIPTION
## SUMMARY

Fixes use-after-free crashes that occur whenever a plugin is unloaded (console `plugins.unload`, RCON, or `.dll.ArkApi` hot-reload staging) while one of its async HTTP requests still has an outstanding callback. Two distinct timing scenarios (queued result and in-flight worker) both reproduce the same crash types. Deprecated 2-arg POST overloads are kept (now `[[deprecated]]`) and route through thin adapters into the new safe code path, preserving full ABI. Several minor bugs and undefined-behavior crash risks are also addressed in the same refactor.

See commit [f109839](https://github.com/ArkServerApi/AsaApi/commit/f109839d1756597ac51402f083facfb63d741eea) for the full implementation.

See commit [44f39ed](https://github.com/ArkServerApi/AsaApi/commit/44f39ed7bfe4b0ca34925ff5fe8edd1753c4696d) for the refactor of the deprecated functions following discussions.

## THE ISSUE

`API::Requests::Create*Request` spawns detached worker threads that capture the caller's `std::function` by value. The `std::function` is essentially a wrapper that holds a pointer back to the actual lambda code inside the plugin's compiled DLL.

When `PluginManager::UnloadPlugin` runs `FreeLibrary`, the plugin's compiled code is unloaded from memory - but the `std::function` wrappers that worker threads captured (and the ones already queued in `RequestsVec_` waiting for the next tick) still exist. Their internal pointers now point at freed memory. **Any copy, move, destructor, or invoke on these dangling wrappers crashes the server** - the callback doesn't even need to fire; just letting one go out of scope (which runs its destructor) is enough to crash.

Two timing scenarios reproduced the crash:

1. **Queued result**: worker finishes before unload; its result sits in `RequestsVec_` awaiting the next game-thread tick; unload runs; next tick invokes through freed vtable.
2. **In-flight worker**: worker is inside Poco I/O when unload runs; on return, it copies/moves/destructs its captured `std::function` through freed vtable.

## THE FIX

Decouple callback storage from worker-thread capture.

- Callbacks live in a host-owned registry (`std::unordered_map<uint64_t, CallbackEntry>`) keyed by a monotonic id. Each entry is tagged with the caller's `HMODULE`, resolved at request-creation time via `_ReturnAddress()` + `GetModuleHandleExA(FROM_ADDRESS | UNCHANGED_REFCOUNT)`.
- Worker threads capture only the id plus POD/STL. No plugin-owned `std::function` ever lives on a detached worker's stack.
- New public method `Requests::UnregisterCallbacksForModule(HMODULE)` erases all entries for a module. Called from `PluginManager::UnloadPlugin` immediately after `Plugin_Unload` and before all other drains and `FreeLibrary`, so callback destructors run while the plugin DLL is still mapped.
- Late-arriving worker results (scenario 2 above) find no matching id in the registry and are silently discarded with a `debug`-level log.

All async `Create*Request` overloads were migrated. The legacy `WriteRequest` embedded-callback path was removed entirely.

## ABI

Public ABI preserved. No signature changes on `Create*Request`, `CreateGetRequestSync`, or `DownloadFile`. The 2-arg POST overloads are now marked `[[deprecated]]` but remain in the public API as thin adapters that route into the new safe code path. Existing plugins compile, link, and run with `[[deprecated]]` warnings only. `UnregisterCallbacksForModule` is purely additive (non-virtual, so no vtable/layout impact).

Net effect for existing plugins: any plugin using the deprecated 2-arg overloads gets a `[[deprecated]]` warning, no source/binary break, and their callbacks now flow through the safe drain path. They implicitly inherit the unload-crash fix without recompiling.

## VALIDATION

- Tested in two live servers with several plugins concurrently executing HTTP requests & callbacks. Live plugin hot-reloads performed on both servers individually and simultaneously, across `*.dll.arkapi`, Console, and RCON paths.
- Tested against a server running the current `1.21` AsaApi version: crashes confirmed on the baseline, none on servers running this fix.

**Tested:**

- Queued-result scenario (drain + no crash)
- In-flight worker scenario (registry miss + no crash)
- 8-way concurrent in-flight (conservation property verified)
- Baseline 1.21 server reproduces the crash
- Existing plugins link without recompile

**Key observation:** In one reload cycle, 8 pending callbacks were drained on unload, and exactly 8 late-arriving worker results hit the registry-miss path post-reload, with zero crashes. Every in-flight callback either drained safely or missed safely; never both, never neither. Pre-fix, those 8 workers were 8 independent crash opportunities.

Representative log trace from the 8-way reload (logs temporarily promoted to `warn` for validation, reverted before commit):

```
[Plugin] UNLOADED.
[API] Drained 8 pending HTTP request callbacks.
[Plugin] LOADING...
[API] Reloaded plugin - Plugin
[API] Received HTTP response for unknown request ID 145. ...
... (7 more identical misses for ids 146-152)
```

Same pattern observed on 1-in-flight, 1-queued, and mixed-load reload cycles.

## SECONDARY FIXES BUNDLED

- **Undefined behavior fix**: `pop_back()` on empty form body in `LaunchPostForm` (guarded).
- **Silent failure fix**: `post_ids`/`post_data` size mismatch in form-POST now logs at `error` level and returns false (previously returned false silently).
- **Log-level tuning**: registry miss kept at `debug` (expected under unload), `id=0` sentinel raised to `critical` (impossible-by-design), `Create*Request` HMODULE-resolution failure logs at `error`, drain count on `UnregisterCallbacksForModule` logs at `debug` (fires routinely on every plugin reload).

## NOTES

- The deprecated 2-arg `CreatePostRequest` overloads in Requests.h are marked `[[deprecated]]` with a migration message pointing callers to the 3-arg variants.
- Raw pointer usage and manual `delete` for `Poco::Net::HTTPClientSession *session = nullptr` is fragile and should be refactored to `unique_ptr` in a follow-up PR.
- This fix addresses specific crash paths in Requests. It does not replace the need for plugins to clean up their own lifecycle state - plugins still need to join threads, release resources, and unregister hooks cleanly.
- The per-plugin `PreventUnloading` flag ([#54](https://github.com/ArkServerApi/AsaApi/pull/54)) remains useful for plugins with genuinely unrecoverable dependencies.
