### PR TITLE
Add HTTP fallback to prevent Error 126

### DIFF
--- a/AsaApi/Core/Private/Tools/Requests.cpp
+++ b/AsaApi/Core/Private/Tools/Requests.cpp
@@ -250,9 +250,17 @@ namespace API
 		{
     		HMODULE HModule = nullptr;
 			
-			if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | 	GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCSTR)address, &HModule)) 
+			if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | 	GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCSTR)address, &HModule))
 			{
         	return HModule;
+			}
+
+			MEMORY_BASIC_INFORMATION mbi{};
+			if (VirtualQuery(address, &mbi, sizeof(mbi)) == sizeof(mbi)
+				&& mbi.State == MEM_COMMIT
+				&& mbi.AllocationBase != nullptr)
+			{
+				return reinterpret_cast<HMODULE>(mbi.AllocationBase);
 			}
 
     		return std::nullopt;


### PR DESCRIPTION
Solution proven to work in a fork with CrosschatAscended etc.

Error: [API][error] Failed to get module handle for caller of CreatePostRequest. Request cancelled. Error code: 126