### PR TITLE
Don't Sleep(10000) on the game thread when a symbol is missing

### DIFF
--- a/AsaApi/Core/Private/Offsets.cpp
+++ b/AsaApi/Core/Private/Offsets.cpp
@@ -119,7 +119,8 @@ namespace API
 		{
 			Log::GetLog()->critical("Failed to get the offset of '{}'.\nRequested by plugin: {}", name, GetCallingModuleName());
 			Log::GetLog()->flush();
-			Sleep(10000);
+			// NOTE: no Sleep() here. This runs on the game thread; sleeping stalls the whole
+			// server (watchdogs see an ~10s hang and restart it). Log and throw instead.
 			throw;
 		}
 
@@ -132,7 +133,8 @@ namespace API
 		{
 			Log::GetLog()->critical("Failed to get the offset of '{}'.\nRequested by plugin: {}", name, GetCallingModuleName());
 			Log::GetLog()->flush();
-			Sleep(10000);
+			// NOTE: no Sleep() here. This runs on the game thread; sleeping stalls the whole
+			// server (watchdogs see an ~10s hang and restart it). Log and throw instead.
 			throw;
 		}
 
@@ -145,7 +147,8 @@ namespace API
 		{
 			Log::GetLog()->critical("Failed to get the offset of '{}'.\nRequested by plugin: {}", name, GetCallingModuleName());
 			Log::GetLog()->flush();
-			Sleep(10000);
+			// NOTE: no Sleep() here. This runs on the game thread; sleeping stalls the whole
+			// server (watchdogs see an ~10s hang and restart it). Log and throw instead.
 			throw;
 		}
 
@@ -166,10 +169,23 @@ namespace API
 	{
 		if (!bitfields_dump_.contains(name))
 		{
-			Log::GetLog()->critical("Failed to get the bitfield address of '{}'.\nRequested by plugin: {}", name, GetCallingModuleName());
-			Log::GetLog()->flush();
-			Sleep(10000);
-			throw;
+			// A missing bitfield must not take the server down. Warn once, then hand back a
+			// bitfield backed by a dummy byte, which reads as false. No Sleep() -- this is the
+			// game thread.
+			static std::unordered_map<std::string, bool> warned;
+			static unsigned long long dummy_storage = 0;
+			if (!warned.contains(name))
+			{
+				warned[name] = true;
+				Log::GetLog()->error("Bitfield '{}' does not exist in this ARK build (requested by plugin: {}). Returning false.", name, GetCallingModuleName());
+				Log::GetLog()->flush();
+			}
+			auto safe = BitField();
+			safe.bit_position = 0;
+			safe.length = 1;
+			safe.num_bits = 1;
+			safe.offset = reinterpret_cast<DWORD64>(&dummy_storage);
+			return safe;
 		}
 
 		const auto bf = bitfields_dump_[name];


### PR DESCRIPTION
Hey @Pelayori — this is the first of the two I mentioned on Discord, turned into code. Small and surgical, as promised.

## The problem

`Offsets::GetAddress`, `GetDataAddress` and `GetBitFieldInternal` all run on the game thread. When a plugin requests a symbol that isn't in the cache, the current code does:

```cpp
Log::GetLog()->critical("Failed to get the offset of '{}'.", ...);
Log::GetLog()->flush();
Sleep(10000);   // <-- game thread
throw;
```

That 10-second sleep stalls the entire server. Watchdogs read it as a hang and restart the process, which kicks everyone online.

Since WildCard stopped shipping the `.pdb`, missing symbols are common — so this path gets hit routinely. I think it's a frequent and widely misattributed cause of "my server restarts by itself": server owners blame their host, their mods, their box. It's these four lines.

## The change

- **`GetAddress` / `GetDataAddress`** — log `critical` and throw, without the sleep. Same behavior, minus the stall.
- **`GetBitFieldInternal`** — a missing bitfield now warns **once** and returns a bitfield backed by a dummy byte, which reads as `false`. The plugin degrades; the server stays up.

The reasoning on that second one: a plugin reading a bitfield that no longer exists should get a wrong-but-safe `false`, not take down a server full of players. The log line still tells the plugin author exactly what to fix.

No API or ABI change — existing compiled plugins are unaffected.
