### PR TITLE
Remove plugin commands and callbacks on unload

### DIFF
--- a/AsaApi/Core/Private/Commands.cpp
+++ b/AsaApi/Core/Private/Commands.cpp
@@ -1,39 +1,55 @@
 #include "Commands.h"
 
+#include <intrin.h>
+
 #include "IBaseApi.h"
+
+namespace
+{
+	HMODULE ModuleFromAddress(void* address)
+	{
+		HMODULE h_module = nullptr;
+		GetModuleHandleExA(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			static_cast<LPCSTR>(address),
+			&h_module);
+
+		return h_module;
+	}
+}
 
 namespace AsaApi
 {
 	void Commands::AddChatCommand(const FString& command,
 		const std::function<void(AShooterPlayerController*, FString*, int, int)>&callback)
 	{
-		chat_commands_.push_back(std::make_shared<ChatCommand>(command, callback));
+		chat_commands_.push_back(std::make_shared<ChatCommand>(command, callback, ModuleFromAddress(_ReturnAddress())));
 	}
 
 	void Commands::AddConsoleCommand(const FString& command,
 		const std::function<void(APlayerController*, FString*, bool)>& callback)
 	{
-		console_commands_.push_back(std::make_shared<ConsoleCommand>(command, callback));
+		console_commands_.push_back(std::make_shared<ConsoleCommand>(command, callback, ModuleFromAddress(_ReturnAddress())));
 	}
 
 	void Commands::AddRconCommand(const FString& command, const std::function<void(RCONClientConnection*, RCONPacket*, UWorld*)>& callback)
 	{
-		rcon_commands_.push_back(std::make_shared<RconCommand>(command, callback));
+		rcon_commands_.push_back(std::make_shared<RconCommand>(command, callback, ModuleFromAddress(_ReturnAddress())));
 	}
 
 	void Commands::AddOnTickCallback(const FString& id, const std::function<void(float)>& callback)
 	{
-		on_tick_callbacks_.push_back(std::make_shared<OnTickCallback>(id, callback));
+		on_tick_callbacks_.push_back(std::make_shared<OnTickCallback>(id, callback, ModuleFromAddress(_ReturnAddress())));
 	}
 
 	void Commands::AddOnTimerCallback(const FString& id, const std::function<void()>& callback)
 	{
-		on_timer_callbacks_.push_back(std::make_shared<OnTimerCallback>(id, callback));
+		on_timer_callbacks_.push_back(std::make_shared<OnTimerCallback>(id, callback, ModuleFromAddress(_ReturnAddress())));
 	}
 
 	void Commands::AddOnChatMessageCallback(const FString& id, const std::function<bool(AShooterPlayerController*, FString*, int, int, bool, bool)>& callback)
 	{
-		on_chat_message_callbacks_.push_back(std::make_shared<OnChatMessageCallback>(id, callback));
+		on_chat_message_callbacks_.push_back(std::make_shared<OnChatMessageCallback>(id, callback, ModuleFromAddress(_ReturnAddress())));
 	}
 
 	bool Commands::RemoveChatCommand(const FString& command)
@@ -88,7 +104,7 @@ namespace AsaApi
 		const auto tmp_tick_callbacks = on_tick_callbacks_;
 		for (const auto& data : tmp_tick_callbacks)
 		{
-			if (data)
+			if (data && data->callback)
 			{
 				data->callback(delta_seconds);
 			}
@@ -100,7 +116,7 @@ namespace AsaApi
 		const auto tmp_timer_callbacks = on_timer_callbacks_;
 		for (const auto& data : tmp_timer_callbacks)
 		{
-			if (data)
+			if (data && data->callback)
 			{
 				data->callback();
 			}
@@ -120,10 +136,26 @@ namespace AsaApi
 		bool prevent_default = false;
 		for (const auto& data : tmp_chat_callbacks)
 		{
-			prevent_default |= data->callback(player_controller, message, mode, platform, spam_check, command_executed);
+			if (data && data->callback)
+			{
+				prevent_default |= data->callback(player_controller, message, mode, platform, spam_check, command_executed);
+			}
 		}
 
 		return prevent_default;
+	}
+
+	void Commands::RemoveAllCommandsFromModule(HMODULE h_module)
+	{
+		if (!h_module)
+			return;
+
+		RemoveCommandsFromModule(chat_commands_, h_module);
+		RemoveCommandsFromModule(console_commands_, h_module);
+		RemoveCommandsFromModule(rcon_commands_, h_module);
+		RemoveCommandsFromModule(on_tick_callbacks_, h_module);
+		RemoveCommandsFromModule(on_timer_callbacks_, h_module);
+		RemoveCommandsFromModule(on_chat_message_callbacks_, h_module);
 	}
 
 	// Free function

--- a/AsaApi/Core/Private/Commands.h
+++ b/AsaApi/Core/Private/Commands.h
@@ -44,18 +44,22 @@ namespace AsaApi
 		void CheckOnTimerCallbacks();
 		bool CheckOnChatMessageCallbacks(AShooterPlayerController* player_controller, FString* message, int mode, int platform, bool spam_check, bool command_executed);
 
+		void RemoveAllCommandsFromModule(HMODULE h_module);
+
 	private:
 		template <typename T>
 		struct Command
 		{
-			Command(FString command, std::function<T> callback)
+			Command(FString command, std::function<T> callback, HMODULE h_module)
 				: command(std::move(command)),
-				callback(std::move(callback))
+				callback(std::move(callback)),
+				h_module(h_module)
 			{
 			}
 
 			FString command;
 			std::function<T> callback;
+			HMODULE h_module;
 		};
 
 		using ChatCommand = Command<void(AShooterPlayerController*, FString*, int, int)>;
@@ -85,6 +89,23 @@ namespace AsaApi
 			return false;
 		}
 
+		template <typename T>
+		void RemoveCommandsFromModule(std::vector<std::shared_ptr<T>>& commands, HMODULE h_module)
+		{
+			for (const auto& data : commands)
+			{
+				// released here because a snapshot taken by a Check* loop can outlive FreeLibrary
+				if (data && data->h_module == h_module)
+					data->callback = nullptr;
+			}
+
+			commands.erase(std::remove_if(commands.begin(), commands.end(),
+				[h_module](const std::shared_ptr<T>& data) -> bool
+				{
+					return !data || data->h_module == h_module;
+				}), commands.end());
+		}
+
 		template <typename T, typename... Args>
 		bool CheckCommands(const FString& message, const std::vector<std::shared_ptr<T>>& commands, Args&&... args)
 		{
@@ -97,10 +118,11 @@ namespace AsaApi
 			}
 
 			const FString command_text = parsed[0];
+			const auto tmp_commands = commands;
 
-			for (const auto& command : commands)
+			for (const auto& command : tmp_commands)
 			{
-				if (command_text.Compare(command->command, ESearchCase::IgnoreCase) == 0)
+				if (command && command->callback && command_text.Compare(command->command, ESearchCase::IgnoreCase) == 0)
 				{
 					command->callback(std::forward<Args>(args)...);
 

--- a/AsaApi/Core/Private/PluginManager/PluginManager.cpp
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.cpp
@@ -8,6 +8,7 @@
 #include "Tools.h"
 
 #include "../IBaseApi.h"
+#include "../Commands.h"
 #include "../Hooks.h"
 #include <Timer.h>
 #include "../Ark/ApiUtils.h"
@@ -206,6 +207,8 @@ namespace API
 
 		API::Timer::Get().UnloadTimersFromModule(FString(full_dll_path).Replace(L"/", L"\\"));
 		dynamic_cast<AsaApi::ApiUtils&>(*API::game_api->GetApiUtils()).RemoveMessagingManagerInternal(FString(full_dll_path).Replace(L"/", L"\\"));
+
+		dynamic_cast<AsaApi::Commands&>(*API::game_api->GetCommands()).RemoveAllCommandsFromModule((*iter)->h_module);
 
 		// Remove all hooks registered by this plugin before freeing its memory,
 		// so no live hook target points into the unloaded DLL image.


### PR DESCRIPTION
Hooks, HTTP callbacks, timers and the messaging manager get cleaned up when a plugin unloads commands never did. Same shape as `DisableAllHooksFromModule`  ech command records the module that registered it via `_ReturnAddress()` and `RemoveAllCommandsFromModule` runs before FreeLibrary.

Erasing alone isn't enough, a Check* loop holds a snapshot that outlives FreeLibrary, so the callback gets cleared while the module is still mapped. CheckCommands snapshots now like the tick loop already did.