### PR TITLE
Skip and quarantine non-essential plugins on missing offsets

### DIFF
--- a/AsaApi/AsaApi.vcxproj
+++ b/AsaApi/AsaApi.vcxproj
@@ -84,6 +84,7 @@
     <ClCompile Include="Core\Private\Logger.cpp" />
     <ClCompile Include="Core\Private\Offsets.cpp" />
     <ClCompile Include="Core\Private\PDBReader\PDBReader.cpp" />
+    <ClCompile Include="Core\Private\PluginManager\EssentialPlugins.cpp" />
     <ClCompile Include="Core\Private\PluginManager\PluginManager.cpp" />
     <ClCompile Include="Core\Private\Tools\Requests.cpp" />
     <ClCompile Include="Core\Private\Tools\Timer.cpp" />
@@ -107,6 +108,7 @@
     <ClInclude Include="Core\Private\IBaseApi.h" />
     <ClInclude Include="Core\Private\Offsets.h" />
     <ClInclude Include="Core\Private\PDBReader\PDBReader.h" />
+    <ClInclude Include="Core\Private\PluginManager\EssentialPlugins.h" />
     <ClInclude Include="Core\Private\PluginManager\PluginManager.h" />
     <ClInclude Include="Core\Public\API\ARK\Actor.h" />
     <ClInclude Include="Core\Public\API\ARK\Ark.h" />

--- a/AsaApi/AsaApi.vcxproj.filters
+++ b/AsaApi/AsaApi.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClCompile Include="Core\Private\PluginManager\PluginManager.cpp">
       <Filter>Source Files\Core\Private\PluginManager</Filter>
     </ClCompile>
+    <ClCompile Include="Core\Private\PluginManager\EssentialPlugins.cpp">
+      <Filter>Source Files\Core\Private\PluginManager</Filter>
+    </ClCompile>
     <ClCompile Include="Core\Public\API\UE\Serialization\Archive.cpp">
       <Filter>Source Files\Core\Public\API\UE\Serialization</Filter>
     </ClCompile>
@@ -2292,6 +2295,9 @@
       <Filter>Source Files\Core\Public</Filter>
     </ClInclude>
     <ClInclude Include="Core\Private\PluginManager\PluginManager.h">
+      <Filter>Source Files\Core\Private\PluginManager</Filter>
+    </ClInclude>
+    <ClInclude Include="Core\Private\PluginManager\EssentialPlugins.h">
       <Filter>Source Files\Core\Private\PluginManager</Filter>
     </ClInclude>
     <ClInclude Include="Core\Public\API\UE\Async\Async.h">

--- a/AsaApi/Core/Private/Offsets.cpp
+++ b/AsaApi/Core/Private/Offsets.cpp
@@ -1,5 +1,6 @@
 #include "Offsets.h"
 #include "Logger/Logger.h"
+#include "PluginManager/EssentialPlugins.h"
 #include <Psapi.h>
 #pragma comment(lib, "Psapi.lib")
 #include <filesystem>
@@ -10,41 +11,13 @@
 
 namespace
 {
-	std::string ModuleName(HMODULE hModule)
-	{
-		if (!hModule)
-			return "<unknown>";
-
-		char path[MAX_PATH]{};
-		if (!GetModuleFileNameA(hModule, path, MAX_PATH))
-			return "<unknown>";
-
-		const std::string full(path);
-		const auto slash = full.find_last_of("\\/");
-		std::string name = (slash != std::string::npos) ? full.substr(slash + 1) : full;
-
-		const auto dot = name.rfind('.');
-		if (dot != std::string::npos)
-			name.erase(dot);
-
-		return name;
-	}
-
 	bool PathPartEquals(const std::filesystem::path& part, const std::string& expected)
 	{
 		return _stricmp(part.string().c_str(), expected.c_str()) == 0;
 	}
 
-	bool IsPluginModule(HMODULE hModule)
+	bool IsPluginModule(const std::filesystem::path& modulePath)
 	{
-		if (!hModule)
-			return false;
-
-		char path[MAX_PATH]{};
-		if (!GetModuleFileNameA(hModule, path, MAX_PATH))
-			return false;
-
-		const std::filesystem::path modulePath(path);
 		const std::filesystem::path pluginDir = modulePath.parent_path();
 
 		// a plugin still inside Plugin_Init is not in loaded_plugins_ yet, so match on the path instead
@@ -52,14 +25,39 @@ namespace
 			&& PathPartEquals(pluginDir.parent_path().filename(), "Plugins");
 	}
 
-	std::string DescribeOffsetRequester()
+	std::filesystem::path ModulePath(HMODULE hModule)
+	{
+		char path[MAX_PATH]{};
+		GetModuleFileNameA(hModule, path, MAX_PATH);
+
+		return std::filesystem::path(path);
+	}
+
+	struct OffsetRequester
+	{
+		std::filesystem::path plugin_dll_path;
+		std::string plugin_name;
+		bool resolved_any = false;
+		bool clean_unwind_to_loader = false;
+	};
+
+	OffsetRequester FindOffsetRequester(const std::string& loadingPlugin)
 	{
 		constexpr int maxFrames = 64;
 		void* stack[maxFrames]{};
 
 		const USHORT frames = CaptureStackBackTrace(1, maxFrames, stack, nullptr);
 
-		bool resolvedAny = false;
+		OffsetRequester requester;
+
+		HMODULE self = nullptr;
+		GetModuleHandleExA(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			reinterpret_cast<LPCSTR>(&FindOffsetRequester),
+			&self);
+
+		// throwing may only unwind AsaApi frames and the loading plugin's own frames
+		bool cleanSoFar = true;
 
 		for (USHORT i = 0; i < frames; ++i)
 		{
@@ -69,19 +67,95 @@ namespace
 				reinterpret_cast<LPCSTR>(stack[i]),
 				&module))
 			{
+				cleanSoFar = false;
 				continue;
 			}
 
-			resolvedAny = true;
+			requester.resolved_any = true;
 
-			if (IsPluginModule(module))
-				return "plugin " + ModuleName(module);
+			const std::filesystem::path modulePath = ModulePath(module);
+			if (!IsPluginModule(modulePath))
+			{
+				if (module != self)
+					cleanSoFar = false;
+				continue;
+			}
+
+			if (requester.plugin_name.empty())
+			{
+				requester.plugin_dll_path = modulePath;
+				requester.plugin_name = modulePath.stem().string();
+
+				if (loadingPlugin.empty())
+					break;
+			}
+
+			if (_stricmp(modulePath.stem().string().c_str(), loadingPlugin.c_str()) == 0)
+				requester.clean_unwind_to_loader = cleanSoFar;
+			else
+				cleanSoFar = false;
 		}
 
-		if (!resolvedAny)
+		return requester;
+	}
+
+	std::string DescribeRequester(const OffsetRequester& requester)
+	{
+		if (!requester.plugin_name.empty())
+			return "plugin " + requester.plugin_name;
+
+		if (!requester.resolved_any)
 			return "<unknown>";
 
 		return "AsaApi itself (no plugin on the call stack)";
+	}
+
+	std::string DescribeOffsetRequester()
+	{
+		return DescribeRequester(FindOffsetRequester(API::EssentialPlugins::CurrentLoadingPlugin()));
+	}
+
+	void LogMissingSymbol(const std::string& name, API::EssentialPlugins::SymbolKind kind, const std::string& requester, const std::string& outcome = "")
+	{
+		const char* what = kind == API::EssentialPlugins::SymbolKind::BitField ? "bitfield address" : "offset";
+
+		if (outcome.empty())
+			Log::GetLog()->critical("Failed to get the {} of '{}'.\nRequested by: {}", what, name, requester);
+		else
+			Log::GetLog()->critical("Failed to get the {} of '{}'.\nRequested by: {}\n{}", what, name, requester, outcome);
+	}
+
+	void HandleMissingSymbol(const std::string& name, API::EssentialPlugins::SymbolKind kind)
+	{
+		const std::string& loadingPlugin = API::EssentialPlugins::CurrentLoadingPlugin();
+		const OffsetRequester requester = FindOffsetRequester(loadingPlugin);
+		const std::string description = DescribeRequester(requester);
+
+		if (requester.clean_unwind_to_loader && !API::EssentialPlugins::IsEssential(loadingPlugin))
+		{
+			LogMissingSymbol(name, kind, description, "Skipping plugin " + loadingPlugin + " (not in EssentialPlugins)");
+			API::EssentialPlugins::NoteLoadFailure(name, kind);
+			Log::GetLog()->flush();
+
+			throw std::runtime_error("missing " + std::string(API::EssentialPlugins::SymbolKindName(kind)) + " '" + name + "'");
+		}
+
+		if (!requester.plugin_name.empty() && !API::EssentialPlugins::IsEssential(requester.plugin_name))
+		{
+			const std::string outcome = API::EssentialPlugins::QuarantineAfterCrash(requester.plugin_dll_path, name, kind);
+			LogMissingSymbol(name, kind, description, outcome);
+		}
+		else
+		{
+			LogMissingSymbol(name, kind, description);
+
+			if (!requester.plugin_name.empty())
+				API::EssentialPlugins::SendCrashWebhook(requester.plugin_name, name, kind);
+		}
+
+		Log::GetLog()->flush();
+		Sleep(10000);
+		throw;
 	}
 } // namespace
 
@@ -143,12 +217,7 @@ namespace API
 	DWORD64 Offsets::GetAddress(const void* base, const std::string& name)
 	{
 		if (!offsets_dump_.contains(name))
-		{
-			Log::GetLog()->critical("Failed to get the offset of '{}'.\nRequested by: {}", name, DescribeOffsetRequester());
-			Log::GetLog()->flush();
-			Sleep(10000);
-			throw;
-		}
+			HandleMissingSymbol(name, EssentialPlugins::SymbolKind::Offset);
 
 		return reinterpret_cast<DWORD64>(base) + static_cast<DWORD64>(offsets_dump_[name]);
 	}
@@ -157,15 +226,14 @@ namespace API
 	{
 		if (!offsets_dump_.contains(name))
 		{
-			Log::GetLog()->critical("Failed to get the offset of '{}'.\nRequested by: {}", name, DescribeOffsetRequester());
-			Log::GetLog()->flush();
 			if (hooks_do_not_throw_)
-				return nullptr;
-			else
 			{
-				Sleep(10000);
-				throw;
+				LogMissingSymbol(name, EssentialPlugins::SymbolKind::Offset, DescribeOffsetRequester());
+				Log::GetLog()->flush();
+				return nullptr;
 			}
+
+			HandleMissingSymbol(name, EssentialPlugins::SymbolKind::Offset);
 		}
 
 		return reinterpret_cast<LPVOID>(module_base_ + static_cast<DWORD64>(offsets_dump_[name]));
@@ -175,15 +243,14 @@ namespace API
 	{
 		if (!offsets_dump_.contains(name))
 		{
-			Log::GetLog()->critical("Failed to get the offset of '{}'.\nRequested by: {}", name, DescribeOffsetRequester());
-			Log::GetLog()->flush();
 			if (hooks_do_not_throw_)
-				return nullptr;
-			else
 			{
-				Sleep(10000);
-				throw;
+				LogMissingSymbol(name, EssentialPlugins::SymbolKind::Offset, DescribeOffsetRequester());
+				Log::GetLog()->flush();
+				return nullptr;
 			}
+
+			HandleMissingSymbol(name, EssentialPlugins::SymbolKind::Offset);
 		}
 
 		return reinterpret_cast<LPVOID>(data_base_ + static_cast<DWORD64>(offsets_dump_[name]));
@@ -199,15 +266,20 @@ namespace API
 		return GetBitFieldInternal(base, name);
 	}
 
+	bool Offsets::HasOffset(const std::string& name) const
+	{
+		return offsets_dump_.contains(name);
+	}
+
+	bool Offsets::HasBitField(const std::string& name) const
+	{
+		return bitfields_dump_.contains(name);
+	}
+
 	BitField Offsets::GetBitFieldInternal(const void* base, const std::string& name)
 	{
 		if (!bitfields_dump_.contains(name))
-		{
-			Log::GetLog()->critical("Failed to get the bitfield address of '{}'.\nRequested by: {}", name, DescribeOffsetRequester());
-			Log::GetLog()->flush();
-			Sleep(10000);
-			throw;
-		}
+			HandleMissingSymbol(name, EssentialPlugins::SymbolKind::BitField);
 
 		const auto bf = bitfields_dump_[name];
 		auto cf = BitField();

--- a/AsaApi/Core/Private/Offsets.h
+++ b/AsaApi/Core/Private/Offsets.h
@@ -27,6 +27,9 @@ namespace API
 		BitField GetBitField(const void* base, const std::string& name);
 		BitField GetBitField(LPVOID base, const std::string& name);
 
+		bool HasOffset(const std::string& name) const;
+		bool HasBitField(const std::string& name) const;
+
 	private:
 		Offsets();
 		~Offsets() = default;

--- a/AsaApi/Core/Private/PluginManager/EssentialPlugins.cpp
+++ b/AsaApi/Core/Private/PluginManager/EssentialPlugins.cpp
@@ -1,0 +1,384 @@
+#include "EssentialPlugins.h"
+
+#include <fstream>
+#include <optional>
+#include <string.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <json.hpp>
+#include <Logger/Logger.h>
+#include <Tools.h>
+
+#include "../Cache.h"
+#include "../Offsets.h"
+#include "Requests.h"
+
+namespace API::EssentialPlugins
+{
+	namespace
+	{
+		constexpr auto marker_file_name = "OffsetCrash.json";
+
+		struct Config
+		{
+			std::optional<std::vector<std::string>> essential_plugins;
+			std::string webhook_url;
+		};
+
+		Config ReadConfig()
+		{
+			Config result;
+
+			try
+			{
+				const std::string config_path = AsaApi::Tools::GetCurrentDir() + "/config.json";
+				std::ifstream file(config_path);
+				if (!file.is_open())
+					return result;
+
+				nlohmann::json cfg;
+				file >> cfg;
+
+				const nlohmann::json essentials = cfg["settings"].value("EssentialPlugins", nlohmann::json::object());
+				if (essentials.value("Enable", false))
+					result.essential_plugins = essentials.value("Plugins", std::vector<std::string>{});
+
+				result.webhook_url = cfg["settings"].value("PluginFailureWebhook", "");
+			}
+			catch (...) {}
+
+			return result;
+		}
+
+		const Config& GetConfig()
+		{
+			static const Config config = ReadConfig();
+			return config;
+		}
+
+		thread_local std::string current_loading_plugin;
+		thread_local LoadFailure pending_load_failure;
+		thread_local bool in_library_load = false;
+
+		thread_local bool report_collecting = false;
+		thread_local std::vector<std::string> report_lines;
+
+		std::filesystem::path MarkerPath(const std::filesystem::path& plugin_dir)
+		{
+			return plugin_dir / marker_file_name;
+		}
+
+		// the diff fence colors the ---- separator lines red
+		std::string FormatWebhookCard(const std::string& header, const std::vector<std::string>& lines)
+		{
+			constexpr auto separator = "--------------------------------------------------";
+
+			std::string card = "```diff\n" + header + "\n" + separator + "\n";
+
+			// discord rejects messages over 2000 characters
+			for (const auto& line : lines)
+			{
+				if (card.size() + line.size() > 1800)
+					break;
+
+				card += line + "\n";
+			}
+
+			card += separator;
+			card += "\n```";
+
+			return card;
+		}
+
+		void PostWebhook(const std::string& content)
+		{
+			const std::string& url = GetConfig().webhook_url;
+			if (url.empty())
+				return;
+
+			// starting the HTTP worker under the loader lock can hang the process
+			if (in_library_load)
+			{
+				Log::GetLog()->warn("Webhook suppressed while a plugin DLL is loading or unloading");
+				return;
+			}
+
+			try
+			{
+				nlohmann::json payload;
+				payload["content"] = content;
+
+				Requests::Get().CreatePostRequest(url,
+					[](bool, std::string, std::unordered_map<std::string, std::string>) {},
+					payload.dump(), "application/json");
+			}
+			catch (...) {}
+		}
+
+		std::optional<SymbolKind> SymbolKindFromName(const std::string& name)
+		{
+			if (name == "offset")
+				return SymbolKind::Offset;
+			if (name == "bitfield")
+				return SymbolKind::BitField;
+
+			return std::nullopt;
+		}
+
+		struct CrashMarker
+		{
+			std::string symbol;
+			SymbolKind kind;
+			std::string dll_hash;
+		};
+
+		std::optional<CrashMarker> ReadCrashMarker(const std::filesystem::path& plugin_dir)
+		{
+			const auto marker_path = MarkerPath(plugin_dir);
+
+			std::error_code error;
+			if (!std::filesystem::exists(marker_path, error))
+				return std::nullopt;
+
+			try
+			{
+				std::ifstream file(marker_path);
+				nlohmann::json json;
+				file >> json;
+
+				CrashMarker marker;
+				marker.symbol = json.value("Symbol", "");
+				marker.dll_hash = json.value("DllHash", "");
+
+				const auto kind = SymbolKindFromName(json.value("SymbolKind", ""));
+				if (kind && !marker.symbol.empty())
+				{
+					marker.kind = *kind;
+					return marker;
+				}
+			}
+			catch (...) {}
+
+			Log::GetLog()->warn("Discarding unreadable {} in '{}'", marker_file_name, plugin_dir.string());
+			ClearCrashMarker(plugin_dir);
+
+			return std::nullopt;
+		}
+
+		bool DllHashMatches(const CrashMarker& marker, const std::filesystem::path& dll_path)
+		{
+			// a read error must not lift the quarantine
+			const std::string current = Cache::calculateSHA256(dll_path);
+			if (current.empty())
+				return true;
+
+			return marker.dll_hash == current;
+		}
+
+		bool SymbolAvailable(const CrashMarker& marker)
+		{
+			return marker.kind == SymbolKind::BitField
+				? Offsets::Get().HasBitField(marker.symbol)
+				: Offsets::Get().HasOffset(marker.symbol);
+		}
+	}
+
+	const char* SymbolKindName(SymbolKind kind)
+	{
+		return kind == SymbolKind::BitField ? "bitfield" : "offset";
+	}
+
+	bool IsEssential(const std::string& plugin_name)
+	{
+		const auto& essential_plugins = GetConfig().essential_plugins;
+		if (!essential_plugins)
+			return true;
+
+		for (const auto& name : *essential_plugins)
+		{
+			if (_stricmp(name.c_str(), plugin_name.c_str()) == 0)
+				return true;
+		}
+
+		return false;
+	}
+
+	void SendWebhookMessage(const std::string& content)
+	{
+		if (GetConfig().webhook_url.empty())
+			return;
+
+		if (report_collecting)
+		{
+			report_lines.push_back(content);
+			return;
+		}
+
+		PostWebhook(FormatWebhookCard("AsaApi - Plugin Report", { content }));
+	}
+
+	// posts immediately: the server is about to terminate, a queued report would never be flushed
+	void SendCrashWebhook(const std::string& plugin_name, const std::string& symbol, SymbolKind kind)
+	{
+		const char* label = GetConfig().essential_plugins ? "Essential plugin" : "Plugin";
+		const std::string message = std::string(label) + " '" + plugin_name + "' crashed the server on missing "
+			+ SymbolKindName(kind) + " '" + symbol + "'";
+
+		PostWebhook(FormatWebhookCard("AsaApi - Plugin Crash", { message }));
+	}
+
+	void BeginWebhookReport()
+	{
+		report_collecting = true;
+		report_lines.clear();
+	}
+
+	void SendWebhookReport()
+	{
+		report_collecting = false;
+
+		if (report_lines.empty())
+			return;
+
+		PostWebhook(FormatWebhookCard("AsaApi - Plugin Report", report_lines));
+		report_lines.clear();
+	}
+
+	PluginLoadGuard::PluginLoadGuard(const std::string& plugin_name)
+	{
+		current_loading_plugin = plugin_name;
+		pending_load_failure = {};
+	}
+
+	PluginLoadGuard::~PluginLoadGuard()
+	{
+		current_loading_plugin.clear();
+		pending_load_failure = {};
+	}
+
+	LoadFailure PluginLoadGuard::TakeFailure()
+	{
+		LoadFailure failure = std::move(pending_load_failure);
+		pending_load_failure = {};
+
+		return failure;
+	}
+
+	LibraryLoadGuard::LibraryLoadGuard()
+		: previous_(in_library_load)
+	{
+		in_library_load = true;
+	}
+
+	LibraryLoadGuard::~LibraryLoadGuard()
+	{
+		in_library_load = previous_;
+	}
+
+	const std::string& CurrentLoadingPlugin()
+	{
+		return current_loading_plugin;
+	}
+
+	void NoteLoadFailure(const std::string& symbol, SymbolKind kind)
+	{
+		pending_load_failure = { symbol, kind };
+	}
+
+	std::string QuarantineAfterCrash(const std::filesystem::path& dll_path, const std::string& symbol, SymbolKind kind)
+	{
+		const std::string plugin_name = dll_path.stem().string();
+
+		try
+		{
+			const std::string missing = std::string(SymbolKindName(kind)) + " '" + symbol + "'";
+
+			// an empty hash reads as a changed dll on the next boot and would retry-crash instead of skip
+			const std::string dll_hash = Cache::calculateSHA256(dll_path);
+
+			bool marker_written = false;
+			if (!dll_hash.empty())
+			{
+				nlohmann::json marker;
+				marker["Symbol"] = symbol;
+				marker["SymbolKind"] = SymbolKindName(kind);
+				marker["DllHash"] = dll_hash;
+
+				marker_written = Cache::saveToFile(MarkerPath(dll_path.parent_path()), marker.dump(4));
+			}
+
+			std::string message;
+			if (marker_written)
+				message = "Plugin '" + plugin_name + "' crashed the server on missing " + missing + " - it will be skipped on the next boot";
+			else
+				message = "Plugin '" + plugin_name + "' crashed the server on missing " + missing + " but writing " + marker_file_name + " failed - it will not be skipped";
+
+			if (report_collecting)
+				SendWebhookMessage(message);
+			else
+				PostWebhook(FormatWebhookCard("AsaApi - Plugin Crash", { message }));
+
+			return message;
+		}
+		catch (...)
+		{
+			Log::GetLog()->warn("Failed to write {} for '{}'", marker_file_name, plugin_name);
+			return {};
+		}
+	}
+
+	bool ShouldSkipQuarantined(const std::filesystem::path& dll_path)
+	{
+		const std::filesystem::path plugin_dir = dll_path.parent_path();
+		const std::string plugin_name = dll_path.stem().string();
+
+		const auto marker = ReadCrashMarker(plugin_dir);
+		if (!marker)
+			return false;
+
+		if (IsEssential(plugin_name))
+		{
+			ClearCrashMarker(plugin_dir);
+			Log::GetLog()->info("Crash marker for '{}' ignored - the plugin is in EssentialPlugins", plugin_name);
+
+			return false;
+		}
+
+		if (!DllHashMatches(*marker, dll_path))
+		{
+			ClearCrashMarker(plugin_dir);
+
+			const std::string message = "Retrying plugin '" + plugin_name + "' - " + plugin_name + ".dll changed since the crash";
+			Log::GetLog()->info("{}", message);
+			SendWebhookMessage(message);
+
+			return false;
+		}
+
+		if (SymbolAvailable(*marker))
+		{
+			ClearCrashMarker(plugin_dir);
+
+			const std::string message = "Retrying plugin '" + plugin_name + "' - " + SymbolKindName(marker->kind) + " '" + marker->symbol + "' is available again";
+			Log::GetLog()->info("{}", message);
+			SendWebhookMessage(message);
+
+			return false;
+		}
+
+		const std::string message = "Skipping plugin '" + plugin_name + "' - crashed earlier on missing "
+			+ SymbolKindName(marker->kind) + " '" + marker->symbol + "'";
+		Log::GetLog()->error("{}", message);
+		SendWebhookMessage(message);
+
+		return true;
+	}
+
+	void ClearCrashMarker(const std::filesystem::path& plugin_dir)
+	{
+		std::error_code error;
+		std::filesystem::remove(MarkerPath(plugin_dir), error);
+	}
+} // namespace API::EssentialPlugins

--- a/AsaApi/Core/Private/PluginManager/EssentialPlugins.h
+++ b/AsaApi/Core/Private/PluginManager/EssentialPlugins.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace API::EssentialPlugins
+{
+	enum class SymbolKind
+	{
+		Offset,
+		BitField
+	};
+
+	const char* SymbolKindName(SymbolKind kind);
+
+	bool IsEssential(const std::string& plugin_name);
+
+	void SendWebhookMessage(const std::string& content);
+	void SendCrashWebhook(const std::string& plugin_name, const std::string& symbol, SymbolKind kind);
+	void BeginWebhookReport();
+	void SendWebhookReport();
+
+	struct LoadFailure
+	{
+		std::string symbol;
+		SymbolKind kind;
+	};
+
+	class PluginLoadGuard
+	{
+	public:
+		PluginLoadGuard(const std::string& plugin_name);
+		~PluginLoadGuard();
+
+		PluginLoadGuard(const PluginLoadGuard&) = delete;
+		PluginLoadGuard& operator=(const PluginLoadGuard&) = delete;
+
+		LoadFailure TakeFailure();
+	};
+
+	class LibraryLoadGuard
+	{
+	public:
+		LibraryLoadGuard();
+		~LibraryLoadGuard();
+
+		LibraryLoadGuard(const LibraryLoadGuard&) = delete;
+		LibraryLoadGuard& operator=(const LibraryLoadGuard&) = delete;
+
+	private:
+		bool previous_;
+	};
+
+	const std::string& CurrentLoadingPlugin();
+
+	void NoteLoadFailure(const std::string& symbol, SymbolKind kind);
+
+	std::string QuarantineAfterCrash(const std::filesystem::path& dll_path, const std::string& symbol, SymbolKind kind);
+	bool ShouldSkipQuarantined(const std::filesystem::path& dll_path);
+	void ClearCrashMarker(const std::filesystem::path& plugin_dir);
+} // namespace API::EssentialPlugins

--- a/AsaApi/Core/Private/PluginManager/PluginManager.cpp
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.cpp
@@ -12,6 +12,7 @@
 #include "../Hooks.h"
 #include <Timer.h>
 #include "../Ark/ApiUtils.h"
+#include "EssentialPlugins.h"
 #include "Requests.h"
 
 namespace API
@@ -45,6 +46,8 @@ namespace API
 
 		const std::string dir_path = Tools::GetCurrentDir() + "/" + game_api->GetApiName() + "/Plugins";
 
+		EssentialPlugins::BeginWebhookReport();
+
 		for (const auto& dir_name : fs::directory_iterator(dir_path))
 		{
 			const auto& path = dir_name.path();
@@ -69,6 +72,9 @@ namespace API
 					fs::remove(new_full_dll_path);
 				}
 
+				if (EssentialPlugins::ShouldSkipQuarantined(full_dll_path))
+					continue;
+
 				std::stringstream stream;
 
 				std::shared_ptr<Plugin>& plugin = LoadPlugin(filename);
@@ -83,6 +89,8 @@ namespace API
 				Log::GetLog()->warn("({}) {}", __FUNCTION__, error.what());
 			}
 		}
+
+		EssentialPlugins::SendWebhookReport();
 
 		CheckPluginsDependencies();
 
@@ -147,21 +155,68 @@ namespace API
 		}
 
 		std::wstring wfull(full_dll_path.begin(), full_dll_path.end());
-		HINSTANCE h_module = LoadLibraryExW(wfull.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS);
+		HINSTANCE h_module = nullptr;
+		{
+			EssentialPlugins::LibraryLoadGuard library_guard;
+			h_module = LoadLibraryExW(wfull.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS);
+		}
 		if (h_module == nullptr)
 		{
+			const DWORD error_code = GetLastError();
+			ReleaseDllDirectory(plugin_name);
 			throw std::runtime_error(
-				"Failed to load plugin - " + plugin_name + "\nError code: " + std::to_string(GetLastError()));
+				"Failed to load plugin - " + plugin_name + "\nError code: " + std::to_string(error_code));
 		}
 
 		// Calls Plugin_Init (if found) after loading DLL
 		// Note: DllMain callbacks during LoadLibrary is load-locked so we cannot do things like WaitForMultipleObjects on threads
+		// Note: the pointer type must keep C++ linkage, an extern "C" type would let /EHc assume it cannot throw and elide the catch below
 		using pfnPluginInit = void(__fastcall*)();
 		const auto pfn_init = reinterpret_cast<pfnPluginInit>(GetProcAddress(h_module, "Plugin_Init"));
 		if (pfn_init != nullptr)
 		{
-			pfn_init();
+			EssentialPlugins::PluginLoadGuard load_guard(plugin_name);
+
+			bool init_threw = false;
+			std::string init_error;
+
+			try
+			{
+				pfn_init();
+			}
+			catch (const std::exception& error)
+			{
+				// error.what() can point into the plugin image, copy it before FreeLibrary
+				init_threw = true;
+				init_error = error.what();
+			}
+			catch (...)
+			{
+				init_threw = true;
+			}
+
+			const auto failure = load_guard.TakeFailure();
+			if (init_threw || !failure.symbol.empty())
+			{
+				EvictFailedPlugin(h_module, plugin_name, full_dll_path);
+
+				if (!failure.symbol.empty())
+				{
+					const std::string message = "Skipped plugin " + plugin_name + " - missing "
+						+ EssentialPlugins::SymbolKindName(failure.kind) + " '" + failure.symbol + "' (not in EssentialPlugins)";
+					EssentialPlugins::SendWebhookMessage(message);
+
+					throw std::runtime_error(message);
+				}
+
+				if (!init_error.empty())
+					throw std::runtime_error("Plugin " + plugin_name + " failed in Plugin_Init - " + init_error);
+
+				throw std::runtime_error("Plugin " + plugin_name + " failed in Plugin_Init");
+			}
 		}
+
+		EssentialPlugins::ClearCrashMarker(dir_path);
 
 		return loaded_plugins_.emplace_back(std::make_shared<Plugin>(h_module, plugin_name, plugin_info["FullName"],
 			plugin_info["Description"], plugin_info["Version"],
@@ -202,34 +257,58 @@ namespace API
 			pfn_unload();
 		}
 
+		CleanupModuleArtifacts((*iter)->h_module, full_dll_path);
+
+		{
+			EssentialPlugins::LibraryLoadGuard library_guard;
+			if (!FreeLibrary((*iter)->h_module))
+			{
+				throw std::runtime_error(
+					"Failed to unload plugin - " + plugin_name + "\nError code: " + std::to_string(GetLastError()));
+			}
+		}
+
+		ReleaseDllDirectory(plugin_name);
+
+		loaded_plugins_.erase(remove(loaded_plugins_.begin(), loaded_plugins_.end(), *iter), loaded_plugins_.end());
+		prevent_unload_warned_plugins_.erase(plugin_name);
+	}
+
+	void PluginManager::CleanupModuleArtifacts(HINSTANCE h_module, const std::string& full_dll_path)
+	{
 		// Cleans up all pending callbacks to prevent a server crash due to stale invocations after the plugin is unloaded.
-		API::Requests::Get().UnregisterCallbacksForModule((*iter)->h_module);
+		API::Requests::Get().UnregisterCallbacksForModule(h_module);
 
-		API::Timer::Get().UnloadTimersFromModule(FString(full_dll_path).Replace(L"/", L"\\"));
-		dynamic_cast<AsaApi::ApiUtils&>(*API::game_api->GetApiUtils()).RemoveMessagingManagerInternal(FString(full_dll_path).Replace(L"/", L"\\"));
+		const FString module_path = FString(full_dll_path).Replace(L"/", L"\\");
+		API::Timer::Get().UnloadTimersFromModule(module_path);
+		dynamic_cast<AsaApi::ApiUtils&>(*API::game_api->GetApiUtils()).RemoveMessagingManagerInternal(module_path);
 
-		dynamic_cast<AsaApi::Commands&>(*API::game_api->GetCommands()).RemoveAllCommandsFromModule((*iter)->h_module);
+		dynamic_cast<AsaApi::Commands&>(*API::game_api->GetCommands()).RemoveAllCommandsFromModule(h_module);
 
 		// Remove all hooks registered by this plugin before freeing its memory,
 		// so no live hook target points into the unloaded DLL image.
-		dynamic_cast<API::Hooks&>(*API::game_api->GetHooks()).DisableAllHooksFromModule((*iter)->h_module);
+		dynamic_cast<API::Hooks&>(*API::game_api->GetHooks()).DisableAllHooksFromModule(h_module);
+	}
 
-		const BOOL result = FreeLibrary((*iter)->h_module);
-		if (result == 0)
-		{
-			throw std::runtime_error(
-				"Failed to unload plugin - " + plugin_name + "\nError code: " + std::to_string(GetLastError()));
-		}
+	void PluginManager::EvictFailedPlugin(HINSTANCE h_module, const std::string& plugin_name, const std::string& full_dll_path)
+	{
+		CleanupModuleArtifacts(h_module, full_dll_path);
 
-		auto cookieIt = dll_dir_cookies_.find(plugin_name);
+		EssentialPlugins::LibraryLoadGuard library_guard;
+		if (!FreeLibrary(h_module))
+			Log::GetLog()->warn("Failed to unload plugin - {}\nError code: {}", plugin_name, GetLastError());
+
+		ReleaseDllDirectory(plugin_name);
+	}
+
+	void PluginManager::ReleaseDllDirectory(const std::string& plugin_name)
+	{
+		const auto cookieIt = dll_dir_cookies_.find(plugin_name);
 		if (cookieIt != dll_dir_cookies_.end())
 		{
 			RemoveDllDirectory(cookieIt->second);
 			dll_dir_cookies_.erase(cookieIt);
 		}
-
-		loaded_plugins_.erase(remove(loaded_plugins_.begin(), loaded_plugins_.end(), *iter), loaded_plugins_.end());
-		prevent_unload_warned_plugins_.erase(plugin_name);
 	}
 
 	nlohmann::json PluginManager::ReadPluginInfo(const std::string& plugin_name)

--- a/AsaApi/Core/Private/PluginManager/PluginManager.h
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.h
@@ -91,6 +91,10 @@ namespace API
 		static nlohmann::json ReadPluginInfo(const std::string& plugin_name);
 		static nlohmann::json ReadSettingsConfig();
 
+		void CleanupModuleArtifacts(HINSTANCE h_module, const std::string& full_dll_path);
+		void EvictFailedPlugin(HINSTANCE h_module, const std::string& plugin_name, const std::string& full_dll_path);
+		void ReleaseDllDirectory(const std::string& plugin_name);
+
 		void CheckPluginsDependencies();
 
 		void DetectPluginChanges();

--- a/Configs/config.json
+++ b/Configs/config.json
@@ -20,6 +20,11 @@
       ]
     },
     "SuppressHttpErrors": false,
-    "HooksDoNotThrow": false
+    "HooksDoNotThrow": false,
+    "EssentialPlugins": {
+      "Enable": false,
+      "Plugins": []
+    },
+    "PluginFailureWebhook": ""
   }
 }


### PR DESCRIPTION

Lets you mark which plugins are allowed to crash the server on a missing offset. Default off, nothing changes:

    "EssentialPlugins": {
        "Enable": true,
        "Plugins": ["Permissions", "ArkShop"]
    },
    "PluginFailureWebhook": "https://discord.com/api/webhooks/..."


Everything not in the list: fails during Plugin_Init -> unloaded again and the server boots without it. Fails at runtime -> the crash stays but it writes an `OffsetCrash.json` next to the .dll first, and the next boot skips that plugin until the dll changes (sha256) or the symbol comes back in a cache update.  A manual plugins.load still overrides the skip, the missing offset doesn't go away though.

The webhook posts one report per boot plus a card when something crashes.

The init skip only throws when the stack is clean, AsaApi frames and the loading plugin's own frames only, anything else takes the marker path. 

Fixed two leaks on the way a throwing Plugin_Init left the dll loaded forever and a failing LoadLibraryExW leaked the AddDllDirectory cookie.


Tested every path on a live server. Might still be best to have a few server owners run this before it goes into a release, I'll leave that call to you, I'm not going to compile and distribute builds myself. Anyone who knows how to compile can of course test it themselves.